### PR TITLE
Migrate to render children

### DIFF
--- a/example/app/new-line.tsx
+++ b/example/app/new-line.tsx
@@ -7,13 +7,9 @@ export default function NewLinePage() {
   return (
     <SimpleData
       renderChart={({ data }) => (
-        <LineChart
-          data={data}
-          xKey="x"
-          yKeys={["y"]}
-          padding={20}
-          renderPaths={({ paths }) => (
-            <React.Fragment>
+        <LineChart data={data} xKey="x" yKeys={["y"]} padding={20}>
+          {({ paths, isActive, xPosition, yPositions }) => (
+            <>
               {paths.map((path, i) => (
                 <Path
                   key={i}
@@ -23,14 +19,12 @@ export default function NewLinePage() {
                   strokeWidth={4}
                 />
               ))}
-            </React.Fragment>
+              {isActive && (
+                <Circle cx={xPosition} cy={yPositions[0]} r={5} color="red" />
+              )}
+            </>
           )}
-          renderTooltip={({ isActive, xPosition, yPositions }) =>
-            isActive && (
-              <Circle cx={xPosition} cy={yPositions[0]} r={5} color="red" />
-            )
-          }
-        />
+        </LineChart>
       )}
     ></SimpleData>
   );

--- a/lib/src/charts/line/LineChart.tsx
+++ b/lib/src/charts/line/LineChart.tsx
@@ -23,28 +23,27 @@ type LineChartProps<T extends InputDatum> = {
   data: T[];
   xKey: string;
   yKeys: string[];
-  renderPaths: (args: { paths: SkPath[] }) => React.ReactNode;
-  renderTooltip?: (args: {
+  // TODO: xScale, yScale
+  // TODO: Axes
+  padding?: SidedNumber;
+  domainPadding?: SidedNumber;
+  children: (args: {
+    paths: SkPath[];
     isActive: boolean;
     xValue: SharedValue<ValueOf<InputDatum>>;
     xPosition: SharedValue<number>;
     yValues: SharedValue<ValueOf<InputDatum>>[];
     yPositions: SharedValue<number>[];
   }) => React.ReactNode;
-  // TODO: xScale, yScale
-  // TODO: Axes
-  padding?: SidedNumber;
-  domainPadding?: SidedNumber;
 };
 
 export function LineChart<T extends InputDatum>({
   data,
   xKey,
   yKeys,
-  renderPaths,
-  renderTooltip,
   padding,
   domainPadding,
+  children,
 }: LineChartProps<T>) {
   const [size, setSize] = React.useState({ width: 0, height: 0 });
   const onLayout = React.useCallback(
@@ -121,8 +120,8 @@ export function LineChart<T extends InputDatum>({
     <GestureHandlerRootView style={{ flex: 1 }}>
       <GestureDetector gesture={pan}>
         <Canvas style={{ flex: 1 }} onLayout={onLayout}>
-          {renderPaths({ paths })}
-          {renderTooltip?.({
+          {children({
+            paths,
             isActive: isTooltipActive,
             xValue: tooltipXValue,
             xPosition: tooltipXPosition,


### PR DESCRIPTION
- Migrates from dual render props to a unified render children model
- This gives the consumer full control over rendering and can layer things as they see fit
- Bonus of being able to evolve the API over time without being stuck to specific render props (thinking of learning lessons from Nuka and Spectacle)