### PR TITLE
Touch improvements

### DIFF
--- a/example/app/stock-price.tsx
+++ b/example/app/stock-price.tsx
@@ -73,6 +73,7 @@ export default function StockPriceScreen() {
           yKeys={["high"]}
           // padding={{ left: 10, right: 10 }}
           curve="linear"
+          isPressEnabled
           activePressX={{ value: activeDateMS }}
           activePressY={{ high: { value: activeHigh } }}
           onPressActiveChange={setIsPressActive}

--- a/lib/src/cartesian/CartesianChart.tsx
+++ b/lib/src/cartesian/CartesianChart.tsx
@@ -39,6 +39,7 @@ type CartesianChartProps<
   padding?: SidedNumber;
   domainPadding?: SidedNumber;
   domain?: { x?: [number] | [number, number]; y?: [number] | [number, number] };
+  isPressEnabled?: boolean;
   onPressActiveStart?: () => void;
   onPressActiveEnd?: () => void;
   onPressActiveChange?: (isPressActive: boolean) => void;
@@ -72,6 +73,7 @@ export function CartesianChart<
   curve,
   padding,
   domainPadding,
+  isPressEnabled,
   onPressActiveChange,
   onPressValueChange,
   onPressActiveStart,
@@ -299,24 +301,30 @@ export function CartesianChart<
     chartBounds.right - chartBounds.left,
     chartBounds.bottom - chartBounds.top,
   );
-  return (
+
+  // Body of the chart.
+  const body = (
+    <Canvas style={{ flex: 1 }} onLayout={onLayout}>
+      {hasMeasuredLayoutSize && renderOutside?.(renderArg)}
+      <Group clip={clipRect}>
+        {hasMeasuredLayoutSize && children(renderArg)}
+      </Group>
+      {gridOptions && <Grid xScale={xScale} yScale={yScale} {...gridOptions} />}
+    </Canvas>
+  );
+
+  // Conditionally wrap the body in gesture handler based on isPressEnabled
+  return isPressEnabled ? (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <GestureDetector gesture={pan}>
-        <Canvas style={{ flex: 1 }} onLayout={onLayout}>
-          {hasMeasuredLayoutSize && renderOutside?.(renderArg)}
-          <Group clip={clipRect}>
-            {hasMeasuredLayoutSize && children(renderArg)}
-          </Group>
-          {gridOptions && (
-            <Grid xScale={xScale} yScale={yScale} {...gridOptions} />
-          )}
-        </Canvas>
-      </GestureDetector>
+      <GestureDetector gesture={pan}>{body}</GestureDetector>
     </GestureHandlerRootView>
+  ) : (
+    body
   );
 }
 
 CartesianChart.defaultProps = {
+  isPressEnabled: false,
   curve: "linear",
   chartType: "line",
   xScaleType: "linear",


### PR DESCRIPTION
This PR updates touch handling a bit:

- `isPressEnabled` prop to conditionally wrap the chart in a gesture handler. If no "active press" functionality required, just don't register the gesture handler.
- Use the `activateAfterLongPress` prop on `Gesture.Pan()` so that we only activate the handler after 100ms of touch. This solves two problems:
  - Can show the "active press" state without actually moving your finger, just by holding it down.
  - Can scroll vertically without triggering the gesture handler, important if a chart is in a scrollable view.


https://github.com/FormidableLabs/victory-native-xl/assets/12721310/fb6d1483-18c5-45f7-bdf0-c5369c796fe1

