### PR TITLE
Remove scaleType for launch

### DIFF
--- a/lib/src/cartesian/CartesianChart.tsx
+++ b/lib/src/cartesian/CartesianChart.tsx
@@ -12,7 +12,6 @@ import {
 import type {
   CartesianChartRenderArg,
   NumericalFields,
-  ScaleType,
   SidedNumber,
   TransformedData,
   PathType,
@@ -38,8 +37,6 @@ type CartesianChartProps<
   xKey: XK;
   yKeys: YK[];
   curve: CurveType | { [K in YK]: CurveType };
-  xScaleType: ScaleType;
-  yScaleType: ScaleType;
   padding?: SidedNumber;
   domainPadding?: SidedNumber;
   domain?: { x?: [number] | [number, number]; y?: [number] | [number, number] };
@@ -77,8 +74,6 @@ export function CartesianChart<
   data,
   xKey,
   yKeys,
-  xScaleType,
-  yScaleType,
   curve,
   padding,
   domainPadding,
@@ -122,8 +117,6 @@ export function CartesianChart<
       data,
       xKey,
       yKeys,
-      xScaleType,
-      yScaleType,
       gridOptions,
       outputWindow: {
         xMin: valueFromSidedNumber(padding, "left"),

--- a/lib/src/cartesian/transformInputData.ts
+++ b/lib/src/cartesian/transformInputData.ts
@@ -1,7 +1,6 @@
 import type {
   NumericalFields,
   PrimitiveViewWindow,
-  ScaleType,
   SidedNumber,
   TransformedData,
 } from "../types";
@@ -35,8 +34,6 @@ export const transformInputData = <
   xKey,
   yKeys,
   outputWindow,
-  xScaleType,
-  yScaleType,
   gridOptions,
   domain,
   domainPadding,
@@ -44,8 +41,6 @@ export const transformInputData = <
   data: RawData[];
   xKey: XK;
   yKeys: YK[];
-  xScaleType: ScaleType;
-  yScaleType: ScaleType;
   outputWindow: PrimitiveViewWindow;
   gridOptions?: Partial<
     Omit<GridProps<RawData, T, XK, YK>, "xScale" | "yScale">
@@ -129,7 +124,6 @@ export const transformInputData = <
   const yScale = makeScale({
     inputBounds: yScaleDomain,
     outputBounds: yScaleRange,
-    scaleType: yScaleType,
     isNice: true,
     padEnd:
       typeof domainPadding === "number" ? domainPadding : domainPadding?.bottom,
@@ -183,7 +177,6 @@ export const transformInputData = <
   })();
 
   const xScale = makeScale({
-    scaleType: xScaleType,
     inputBounds: [ixMin, ixMax],
     outputBounds: oRange,
     padStart:

--- a/lib/src/cartesian/utils/makeScale.ts
+++ b/lib/src/cartesian/utils/makeScale.ts
@@ -1,13 +1,6 @@
-import type { ScaleType } from "../../types";
-import {
-  type ScaleLinear,
-  scaleLinear,
-  scaleLog,
-  type ScaleLogarithmic,
-} from "d3-scale";
+import { type ScaleLinear, scaleLinear } from "d3-scale";
 
 export const makeScale = ({
-  scaleType,
   inputBounds,
   outputBounds,
   padStart,
@@ -16,29 +9,22 @@ export const makeScale = ({
 }: {
   inputBounds: [number, number];
   outputBounds: [number, number];
-  scaleType: ScaleType;
   padStart?: number;
   padEnd?: number;
   isNice?: boolean;
-}): ScaleLinear<number, number> | ScaleLogarithmic<number, number> => {
+}): ScaleLinear<number, number> => {
   // Linear
-  if (scaleType === "linear") {
-    const scale = scaleLinear().domain(inputBounds).range(outputBounds);
+  const scale = scaleLinear().domain(inputBounds).range(outputBounds);
 
-    if (padStart || padEnd) {
-      scale
-        .domain([
-          scale.invert(outputBounds[0] - (padStart ?? 0)),
-          scale.invert(outputBounds[1] + (padEnd ?? 0)),
-        ])
-        .range(outputBounds);
-    }
-
-    if (isNice) scale.nice();
-    return scale;
+  if (padStart || padEnd) {
+    scale
+      .domain([
+        scale.invert(outputBounds[0] - (padStart ?? 0)),
+        scale.invert(outputBounds[1] + (padEnd ?? 0)),
+      ])
+      .range(outputBounds);
   }
 
-  // Log
-  // TODO: Padding, clean 0-values
-  return scaleLog().domain(inputBounds).range(outputBounds);
+  if (isNice) scale.nice();
+  return scale;
 };

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -47,8 +47,6 @@ export type SidedNumber =
   | number
   | { left?: number; right?: number; top?: number; bottom?: number };
 
-export type ScaleType = "linear" | "log";
-
 /**
  * Render arg for our line chart.
  */


### PR DESCRIPTION
I think for launch, we focus on just linear scales. Log scale adds complexity, and I'm not sure if we'd need it or not (plus, you can manually create a log scale from a linear scale with a little data massaging with `x => Math.log(x)`). 

This PR just removes the `ScaleType` options which simplifies some code here and there.