### PR TITLE
Fix crash on Line Chart when changing colors

### DIFF
--- a/lib/src/cartesian/components/AnimatedPath.tsx
+++ b/lib/src/cartesian/components/AnimatedPath.tsx
@@ -5,6 +5,7 @@ import type {
   SkPath,
 } from "@shopify/react-native-skia";
 import { Path } from "@shopify/react-native-skia";
+import { convertToRGBA, useDerivedValue } from "react-native-reanimated";
 import {
   type PathAnimationConfig,
   useAnimatedPath,
@@ -15,7 +16,20 @@ type AnimatedPathProps = { path: SkPath } & SkiaDefaultProps<
   "start" | "end"
 > & { animate?: PathAnimationConfig };
 
-export function AnimatedPath({ path, animate, ...rest }: AnimatedPathProps) {
+export function AnimatedPath({
+  path,
+  animate,
+  color,
+  ...rest
+}: AnimatedPathProps) {
   const p = useAnimatedPath(path, animate);
-  return <Path path={p} {...rest} />;
+
+  // this is done to fix a potential crash with Skia
+  // where the color prop must also be a shared/derived value
+  // if the path is a shared/derived value.
+  const myColor = useDerivedValue(() =>
+    color ? convertToRGBA(color) : undefined,
+  );
+
+  return <Path path={p} color={myColor} {...rest} />;
 }


### PR DESCRIPTION
Fixes an issue on the Line Chart where changing the color of the path for an AnimatedPath would cause a crash within Skia.