### PR TITLE
Include `src` in output

### DIFF
--- a/.changeset/metal-otters-occur.md
+++ b/.changeset/metal-otters-occur.md
@@ -1,0 +1,5 @@
+---
+"victory-native": patch
+---
+
+Include src files in distribution tarball

--- a/lib/package.json
+++ b/lib/package.json
@@ -16,6 +16,7 @@
     ]
   },
   "files": [
+    "src",
     "dist"
   ],
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -31,9 +31,10 @@
     "d3-shape": "^3.2.0",
     "react-fast-compare": "^3.2.2"
   },
+  "TODO:peerDeps": "I think skia/reanimated/rngh peerDeps are pretty aggressive right now, probably need to relax them",
   "peerDependencies": {
-    "react": ">=18.0.0",
-    "react-native": ">=0.70.0",
+    "react": "*",
+    "react-native": "*",
     "@shopify/react-native-skia": ">=0.1.196",
     "react-native-reanimated": ">=3.3.0",
     "react-native-gesture-handler": ">=2.12.0"


### PR DESCRIPTION
Includes `src` files in output. Also laxes react/react-native peer deps versions, adds a note about looking into loosening peer deps for skia/rngh/reanimated.