### PR TITLE
Add 'roundedCorners' prop to BarGroup component

### DIFF
--- a/.changeset/angry-ways-trade.md
+++ b/.changeset/angry-ways-trade.md
@@ -1,0 +1,5 @@
+---
+"victory-native": patch
+---
+
+Add 'roundedCorners' prop to 'BarGroup' component

--- a/.changeset/neat-ladybugs-melt.md
+++ b/.changeset/neat-ladybugs-melt.md
@@ -1,0 +1,5 @@
+---
+"victory-native": minor
+---
+
+Add 'roundedCorners' prop to 'BarGroup' component

--- a/.changeset/neat-ladybugs-melt.md
+++ b/.changeset/neat-ladybugs-melt.md
@@ -1,5 +1,0 @@
----
-"victory-native": minor
----
-
-Add 'roundedCorners' prop to 'BarGroup' component

--- a/example/app/bar-group.tsx
+++ b/example/app/bar-group.tsx
@@ -23,6 +23,7 @@ export default function BarGroupPage(props: { segment: string }) {
   const [data, setData] = React.useState(DATA(5));
   const [betweenGroupPadding, setBetweenGroupPadding] = React.useState(0.4);
   const [withinGroupPadding, setWithinGroupPadding] = React.useState(0.1);
+  const [roundedCorner, setRoundedCorner] = React.useState(0);
   const font = useFont(inter, 12);
   const isDark = useDarkMode();
 
@@ -48,6 +49,10 @@ export default function BarGroupPage(props: { segment: string }) {
               chartBounds={chartBounds}
               betweenGroupPadding={betweenGroupPadding}
               withinGroupPadding={withinGroupPadding}
+              roundedCorners={{
+                topLeft: roundedCorner,
+                topRight: roundedCorner,
+              }}
             >
               <BarGroup.Bar points={points.y} animate={{ type: "timing" }}>
                 <LinearGradient
@@ -107,6 +112,14 @@ export default function BarGroupPage(props: { segment: string }) {
           step={0.1}
           value={withinGroupPadding}
           onChange={setWithinGroupPadding}
+        />
+        <InputSlider
+          label="Top Corner Radius"
+          maxValue={16}
+          minValue={0}
+          step={1}
+          value={roundedCorner}
+          onChange={setRoundedCorner}
         />
       </ScrollView>
     </SafeAreaView>

--- a/lib/src/cartesian/components/BarGroup.tsx
+++ b/lib/src/cartesian/components/BarGroup.tsx
@@ -4,11 +4,13 @@ import type { ChartBounds, PointsArray } from "../../types";
 import type { PathAnimationConfig } from "../../hooks/useAnimatedPath";
 import { AnimatedPath } from "./AnimatedPath";
 import { useBarGroupPaths } from "../hooks/useBarGroupPaths";
+import type { RoundedCorners } from "../../utils/createRoundedRectPath";
 
 type BarGroupProps = {
   chartBounds: ChartBounds;
   betweenGroupPadding?: number;
   withinGroupPadding?: number;
+  roundedCorners?: RoundedCorners;
   children: React.ReactElement[];
   onBarSizeChange?: (values: {
     barWidth: number;
@@ -21,6 +23,7 @@ export function BarGroup({
   betweenGroupPadding = 0.25,
   withinGroupPadding = 0.25,
   chartBounds,
+  roundedCorners,
   children,
   onBarSizeChange,
 }: BarGroupProps) {
@@ -38,6 +41,7 @@ export function BarGroup({
     chartBounds,
     betweenGroupPadding,
     withinGroupPadding,
+    roundedCorners,
   );
 
   // Handle bar size change

--- a/lib/src/cartesian/hooks/useBarGroupPaths.ts
+++ b/lib/src/cartesian/hooks/useBarGroupPaths.ts
@@ -1,12 +1,17 @@
 import * as React from "react";
 import { Skia } from "@shopify/react-native-skia";
 import type { ChartBounds, PointsArray } from "../../types";
+import {
+  createRoundedRectPath,
+  type RoundedCorners,
+} from "../../utils/createRoundedRectPath";
 
 export const useBarGroupPaths = (
   points: PointsArray[],
   chartBounds: ChartBounds,
   betweenGroupPadding = 0,
   withinGroupPadding = 0,
+  roundedCorners?: RoundedCorners,
 ) => {
   const numGroups = points[0]?.length || 0;
 
@@ -33,13 +38,33 @@ export const useBarGroupPaths = (
       const offset = -groupWidth / 2 + i * (barWidth + gapWidth);
 
       pointSet.forEach(({ x, y }) => {
-        p.addRect(
-          Skia.XYWHRect(x + offset, y, barWidth, chartBounds.bottom - y),
-        );
+        if (!roundedCorners) {
+          p.addRect(
+            Skia.XYWHRect(x + offset, y, barWidth, chartBounds.bottom - y),
+          );
+        } else {
+          const roundedRectPath = Skia.Path.MakeFromSVGString(
+            createRoundedRectPath(
+              x + offset,
+              y,
+              barWidth,
+              chartBounds.bottom - y,
+              roundedCorners,
+            ),
+          );
+          roundedRectPath && p.addPath(roundedRectPath);
+        }
       });
       return p;
     });
-  }, [barWidth, chartBounds.bottom, gapWidth, groupWidth, points]);
+  }, [
+    barWidth,
+    chartBounds.bottom,
+    gapWidth,
+    groupWidth,
+    points,
+    roundedCorners,
+  ]);
 
   return { barWidth, groupWidth, gapWidth, paths };
 };

--- a/website/docs/cartesian/bar/bar-group.md
+++ b/website/docs/cartesian/bar/bar-group.md
@@ -60,6 +60,15 @@ onBarSizeChange: (values: {
 
 That alerts the consumer when the size of the bars/groups changes, useful for if you're building a custom tooltip and need to know the size of the groups/bars.
 
+### `roundedCorners`
+
+The `roundedCorners` prop allows you to customize the roundedness of each corner of a `BarGroup.Bar` component. It's an object type that defines the radii for the top-left, top-right, bottom-right, and bottom-left corners.
+
+- `topLeft?: number`: Defines the radius of the top-left corner of the Bar. If not provided, the default is 0 (no rounding).
+- `topRight?: number`: Defines the radius of the top-right corner of the Bar. If not provided, the default is 0 (no rounding).
+- `bottomRight?: number`: Defines the radius of the bottom-right corner of the Bar. If not provided, the default is 0 (no rounding).
+- `bottomLeft?: number`: Defines the radius of the bottom-left corner of the Bar. If not provided, the default is 0 (no rounding).
+
 ### `children`
 
 An array of `BarGroup.Bar` elements (see below) that represent the bars to add to the bar group.


### PR DESCRIPTION
Adds a new 'roundedCorners' prop to the BarGroup component to allow specifiying the roundedness of each contained BarGroup.Bar.

Resolves #113 