### PR TITLE
BarGroup With Tooltip: Don't cap domain

### DIFF
--- a/example/app/bar-with-tooltip.tsx
+++ b/example/app/bar-with-tooltip.tsx
@@ -99,7 +99,7 @@ export default function BarGroupWithTooltipPage(props: { segment: string }) {
           data={DATA}
           xKey="month"
           yKeys={["low", "high"]}
-          domain={{ y: [0, 50] }}
+          domain={{ y: [0] }}
           padding={{ left: 10, right: 10, bottom: 5, top: 15 }}
           domainPadding={{ left: 50, right: 50, top: 30 }}
           axisOptions={{


### PR DESCRIPTION
This PR removes the upper domain cap on the `bar-with-tooltip` example.