### PR TITLE
Docusaurus banner

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -63,8 +63,8 @@ const config = {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
       announcementBar: {
-        id: "supportus",
-        content: `These docs are for version 40 of Victory Native. If you're looking for docs on versions &le;36, please <a href="https://formidable.com/open-source/victory/docs/native" rel="noreferrer" target="_blank">see here</a>.`,
+        id: "legacy_docs",
+        content: `These docs are for version &ge;40 of Victory Native. If you're looking for docs on versions &le;36, please <a href="https://formidable.com/open-source/victory/docs/native" rel="noreferrer" target="_blank">see here</a>.`,
         textColor: "var(--banner-text)",
         backgroundColor: "var(--banner-bg)",
       },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -64,7 +64,7 @@ const config = {
     ({
       announcementBar: {
         id: "supportus",
-        content: `These docs are for version 40 of Victory Native. If you're looking for docs on versions <=36, please <a href="https://formidable.com/open-source/victory/docs/native" rel="noreferrer" target="_blank">see here</a>.`,
+        content: `These docs are for version 40 of Victory Native. If you're looking for docs on versions &le;36, please <a href="https://formidable.com/open-source/victory/docs/native" rel="noreferrer" target="_blank">see here</a>.`,
         textColor: "var(--banner-text)",
         backgroundColor: "var(--banner-bg)",
       },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -62,6 +62,13 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      announcementBar: {
+        id: "supportus",
+        content: `These docs are for version 40 of Victory Native. If you're looking for docs on versions <=36, please <a href="https://formidable.com/open-source/victory/docs/native" rel="noreferrer" target="_blank">see here</a>.`,
+        textColor: "var(--banner-text)",
+        backgroundColor: "var(--banner-bg)",
+      },
+
       navbar: {
         title: "VICTORY NATIVE XL",
         logo: {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -17,6 +17,8 @@
   --ifm-color-primary-lighter: #ED6850;
   --ifm-color-primary-lightest: #F18068;
   --ifm-code-font-size: 95%;
+  --banner-bg: #f7bbae;
+  --banner-text: black;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 }
 
@@ -29,6 +31,8 @@
   --ifm-color-primary-light: #E75741;
   --ifm-color-primary-lighter: #EA6E5B;
   --ifm-color-primary-lightest: #F08673;
+  --banner-bg: #591608;
+  --banner-text: white;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
 


### PR DESCRIPTION
Addresses #125, adds a banner to the documentation to point viewers to the old docs if they're looking for docs on VN prior to version 40.

![image](https://github.com/FormidableLabs/victory-native-xl/assets/12721310/bd72eb54-bc64-48be-a2fe-2581cb79facb)
