### PR TITLE
Skip rendering bar if no y value provided

### DIFF
--- a/lib/src/cartesian/hooks/useBarPath.ts
+++ b/lib/src/cartesian/hooks/useBarPath.ts
@@ -22,6 +22,9 @@ export const useBarPath = (
     const path = Skia.Path.Make();
 
     points.forEach(({ x, y }) => {
+      // Skip drawing bar if no y value provided (see also transformInputData)
+      if (isNaN(y)) return;
+
       if (!roundedCorners) {
         path.addRect(
           Skia.XYWHRect(x - barWidth / 2, y, barWidth, chartBounds.bottom - y),

--- a/lib/src/cartesian/utils/transformInputData.ts
+++ b/lib/src/cartesian/utils/transformInputData.ts
@@ -139,11 +139,14 @@ export const transformInputData = <
   });
 
   yKeys.forEach((yKey) => {
-    y[yKey].i = data.map((datum) => asNumber(datum[yKey]));
-    y[yKey].o = data.map((datum) => yScale(asNumber(datum[yKey])));
+    // Filter out non-numerical values (i.e. if the bar shouldn't exist)
+    const filtered = data.filter((datum) => typeof datum[yKey] === "number");
+
+    y[yKey].i = filtered.map((datum) => asNumber(datum[yKey]));
+    y[yKey].o = filtered.map((datum) => yScale(asNumber(datum[yKey])));
   });
 
-  // Measure our top-most y-label if we have grid options so we can
+  // Measure our top-most y-label if we have grid options, so we can
   //  compensate for it in our x-scale.
   const topYLabel =
     axisOptions?.formatYLabel?.(yScale.domain().at(0) as RawData[YK]) ||


### PR DESCRIPTION

### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Issue of chart rendering a bar with a y value of `0` when in fact no y value was provided. This is almost essential on time-series charts where I wish to display data for a period of time, but may not have all the data yet (being either the future or missing historical data)

Due to the nature of the data prop being `Record<string, number>[]`, if you have missing data pieces but you're trying to render multiple data sources on the same graph it would still attempt to render `null` values as the value of `0`. 

The multiple calls to `asNumber` has some very weird behavior, since the first call in `transformInputData.ts` would convert to `NaN`, and the second call in `useBarPath.ts` would convert to `0`. I don't think this is intended behavior, so I'm removing the duplicated calls in the case where the Y value is simply not provided.

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

Unsure if before was intended behavior or not. See above issue with multiple `asNumber` calls
### How Has This Been Tested?
I created some data with null or undefined values in the graph. 

As you can see, without this change the graph looks like the following:
<img width="150" alt="before change" src="https://github.com/FormidableLabs/victory-native-xl/assets/10779381/84e8f257-2794-46ee-8fba-72b7fee3dd19">

And with this change the graph now correctly removes bars which are represented by `null` y values.
<img width="150" alt="after change" src="https://github.com/FormidableLabs/victory-native-xl/assets/10779381/7c1ed8b2-7b23-414c-b23e-f3645cc86c1e">
