### PR TITLE
Exit prerelease

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "next",
   "initialVersions": {
     "example": "1.0.0",


### PR DESCRIPTION
This PR exits prerelease mode via `yarn changeset pre exit` and `yarn changeset version`, following [this guide](https://github.com/changesets/changesets/blob/main/docs/prereleases.md).

The guide makes me think this will not automatically publish v40, might have to manually cut that release with `yarn changeset publish` – but just wanted some eyes on this first.