### PR TITLE
Remove pre-prod disclaimer

### DIFF
--- a/.changeset/brave-guests-return.md
+++ b/.changeset/brave-guests-return.md
@@ -1,0 +1,5 @@
+---
+"victory-native": patch
+---
+
+Remove pre-production disclaimer from README

--- a/README.md
+++ b/README.md
@@ -33,11 +33,6 @@ https://github.com/FormidableLabs/victory-native-xl/assets/12721310/20bada2d-990
 
 </div>
 
-
-## ⚠️ Pre-Production Disclamer
-
-Victory Native XL is set to replace the current stable version. However, please be advised that it's currently in a pre-production release (beta stage). While many of the new features and improvements are exciting, there might still be some shifts in APIs or bugs that need to be ironed out. We encourage users to test it and provide feedback, but also to be cautious and avoid using it in critical production environments until it has been further stabilized. Your feedback and contributions during this phase will be invaluable in ensuring the robustness of the next stable release.
-
 ## Installation
 
 Start by installing the peer dependencies of `victory-native` – React Native Reanimated, Gesture Handler, and Skia:
@@ -48,10 +43,10 @@ yarn add react-native-reanimated react-native-gesture-handler @shopify/react-nat
 
 For Reanimated, you'll need to add `"react-native-reanimated/plugin"` to your `plugins` list in your `babel.config.js` config file.
 
-Then install `victory-native@next`:
+Then install `victory-native`:
 
 ```shell
-yarn add victory-native@next
+yarn add victory-native
 ```
 
 To get started and read more about the API, view the [docs here](https://formidable.com/open-source/victory-native).

--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -13,10 +13,10 @@ yarn add react-native-reanimated react-native-gesture-handler react-native-skia
 
 For Reanimated, you'll need to add `"react-native-reanimated/plugin"` to your `plugins` list in your `babel.config.js` config file.
 
-Then install `victory-native@next`:
+Then install `victory-native`:
 
 ```shell
-yarn add victory-native@next
+yarn add victory-native
 ```
 
 Now you should be ready to go.

--- a/website/docs/introduction.mdx
+++ b/website/docs/introduction.mdx
@@ -8,7 +8,7 @@ import areaMp4 from "./img/area-fps.mp4";
 
 # Introduction
 
-Victory Native (XL) is a from-scratch rewrite of Victory Native that favors flexibility, ease of use, and **performance**. Currently, this is a pre-release project, and we are looking for feedback from the community. Please open issues for any bugs or feature requests you have.
+Victory Native (XL) is a from-scratch rewrite of Victory Native that favors flexibility, ease of use, and **performance**.
 
 <div className="flex flex-col pb-5 md:pb-10 items-center">
   <div className="flex flex-col md:flex-row gap-5 items-center max-w-full">


### PR DESCRIPTION
This PR removes pre-prod disclaimer, and has install instructions of `yarn add victory-native` (instead of `victory-native@next`).