### PR TITLE
Don't coerce null values to 0

### DIFF
--- a/.changeset/dull-peaches-leave.md
+++ b/.changeset/dull-peaches-leave.md
@@ -1,0 +1,5 @@
+---
+"victory-native": patch
+---
+
+Fix asNumber per #135 so that null values don't get coerced to 0

--- a/example/app/missing-data.tsx
+++ b/example/app/missing-data.tsx
@@ -1,7 +1,14 @@
 import * as React from "react";
 import { SafeAreaView, ScrollView, StyleSheet, View } from "react-native";
-import { Area, Bar, CartesianChart, Line, Scatter } from "victory-native";
-import { useFont } from "@shopify/react-native-skia";
+import {
+  Area,
+  Bar,
+  CartesianChart,
+  Line,
+  Scatter,
+  useChartPressState,
+} from "victory-native";
+import { Circle, useFont } from "@shopify/react-native-skia";
 import { appColors } from "./consts/colors";
 import inter from "../assets/inter-medium.ttf";
 import { Button } from "../components/Button";
@@ -10,7 +17,8 @@ import { InputSegment } from "../components/InputSegment";
 export default function MissingDataScreen() {
   const font = useFont(inter, 12);
   const [data, setData] = React.useState(DATA);
-  const [connectedData, setConnectedData] = React.useState(VALUES[0]!);
+  const [connectedData, setConnectedData] = React.useState(VALUES[1]!);
+  const { state, isActive } = useChartPressState({ x: 0, y: { y: 0 } });
 
   return (
     <SafeAreaView style={styles.safeView}>
@@ -21,6 +29,7 @@ export default function MissingDataScreen() {
           yKeys={["y"]}
           domain={{ y: [0, 100] }}
           axisOptions={{ font }}
+          chartPressState={state}
         >
           {({ points, chartBounds }) => (
             <>
@@ -53,6 +62,10 @@ export default function MissingDataScreen() {
                 shape="star"
                 animate={{ type: "timing" }}
               />
+
+              {isActive && (
+                <Circle r={20} cx={state.x.position} cy={state.y.y.position} />
+              )}
             </>
           )}
         </CartesianChart>
@@ -81,7 +94,7 @@ const DATA = () =>
   Array.from({ length: 20 }, (_, i) => {
     return {
       x: i,
-      y: SKIP.includes(i) ? undefined : Math.random() * 100,
+      y: SKIP.includes(i) ? null : Math.random() * 100,
     };
   });
 

--- a/lib/src/cartesian/utils/transformInputData.ts
+++ b/lib/src/cartesian/utils/transformInputData.ts
@@ -6,6 +6,7 @@ import type {
   SidedNumber,
   TransformedData,
   InputFields,
+  MaybeNumber,
 } from "../../types";
 import { asNumber } from "../../utils/asNumber";
 import { makeScale } from "./makeScale";
@@ -145,8 +146,13 @@ export const transformInputData = <
   });
 
   yKeys.forEach((yKey) => {
-    y[yKey].i = data.map((datum) => asNumber(datum[yKey]));
-    y[yKey].o = data.map((datum) => yScale(asNumber(datum[yKey])));
+    y[yKey].i = data.map((datum) => datum[yKey] as MaybeNumber);
+    y[yKey].o = data.map(
+      (datum) =>
+        (typeof datum[yKey] === "number"
+          ? yScale(datum[yKey] as number)
+          : datum[yKey]) as MaybeNumber,
+    );
   });
 
   // Measure our top-most y-label if we have grid options so we can

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -11,6 +11,7 @@ export {
   type XAxisSide,
   type PointsArray,
   type Scale,
+  type MaybeNumber,
 } from "./types";
 export { type CurveType } from "./cartesian/utils/curves";
 export { type RoundedCorners } from "./utils/createRoundedRectPath";

--- a/lib/src/utils/asNumber.test.ts
+++ b/lib/src/utils/asNumber.test.ts
@@ -6,10 +6,10 @@ describe("asNumber", () => {
     expect(asNumber(1)).toBe(1);
   });
 
-  it("should cast to number if not a number", () => {
-    expect(asNumber("1")).toBe(1);
-    expect(asNumber(false)).toBe(0);
-    expect(asNumber(true)).toBe(1);
+  it("return NaN if not a number", () => {
+    expect(asNumber("1")).toBe(NaN);
+    expect(asNumber(false)).toBe(NaN);
+    expect(asNumber(true)).toBe(NaN);
     expect(asNumber(undefined)).toBe(NaN);
   });
 });

--- a/lib/src/utils/asNumber.ts
+++ b/lib/src/utils/asNumber.ts
@@ -1,4 +1,4 @@
 export const asNumber = (val: unknown): number => {
   "worklet";
-  return typeof val === "number" ? val : Number(val);
+  return typeof val === "number" ? val : NaN;
 };

--- a/website/docs/cartesian/cartesian-chart.md
+++ b/website/docs/cartesian/cartesian-chart.md
@@ -111,6 +111,10 @@ The `chartPressState` prop allows you to pass in Reanimated `SharedValue`s that 
 
 The `chartPressState` prop has a type of `ChartPressState | ChartPressState[]`, where `ChartPressState` is an object generated from the `useChartPressState` hook.
 
+:::info
+If you have a data point whose y-value is `null` or `undefined`, when that point is "active" the gesture state will return `NaN` for the y-value and y-position.
+:::
+
 ### `renderOutside`
 
 The `renderOutside` prop is identical to [the `children` prop](#children-required) in form, but it will render elements at the root of the Skia canvas (not inside of a clipping group). This allows you to render elements outside of the bounds of any axes that you have configured.


### PR DESCRIPTION
Addresses #135. In #129 I handled the case of `undefined` y-values, but totally botched `null` values. This PR follows up with a fix for that:

- `transformInputData` should not be casting y-values, since that masks the true values.
- For gesture state, still using the `asNumber` to make consumption easier – but casting `null/undefined` to `NaN` which plays fine with Skia/Reanimated but allows you to detect when you've got missing data.