### PR TITLE
Add data length prop to calculate barWidth

### DIFF
--- a/lib/src/cartesian/components/Bar.tsx
+++ b/lib/src/cartesian/components/Bar.tsx
@@ -13,6 +13,12 @@ type CartesianBarProps = {
   innerPadding?: number;
   animate?: PathAnimationConfig;
   roundedCorners?: RoundedCorners;
+  /**
+   * Known data length to calculate bar width.
+   *
+   * Set if you'd like to override the default `points.length` check.
+   */
+  dataLength?: number;
 } & Partial<Pick<PathProps, "color" | "blendMode" | "opacity" | "antiAlias">>;
 
 export const Bar = ({

--- a/lib/src/cartesian/hooks/useBarPath.ts
+++ b/lib/src/cartesian/hooks/useBarPath.ts
@@ -11,12 +11,20 @@ export const useBarPath = (
   chartBounds: ChartBounds,
   innerPadding = 0.2,
   roundedCorners?: RoundedCorners,
+  dataLength?: number,
 ) => {
   const barWidth = React.useMemo(() => {
+    const length = dataLength ?? points.length;
     const domainWidth = chartBounds.right - chartBounds.left;
-    const barWidth = ((1 - innerPadding) * domainWidth) / (points.length - 1);
+    const barWidth = ((1 - innerPadding) * domainWidth) / (length - 1);
     return barWidth;
-  }, [chartBounds.left, chartBounds.right, innerPadding, points.length]);
+  }, [
+    chartBounds.left,
+    chartBounds.right,
+    innerPadding,
+    points.length,
+    dataLength,
+  ]);
 
   const path = React.useMemo(() => {
     const path = Skia.Path.Make();

--- a/website/docs/cartesian/bar/bar.md
+++ b/website/docs/cartesian/bar/bar.md
@@ -62,7 +62,7 @@ The `roundedCorners` prop allows you to customize the roundedness of each corner
 
 An optional `dataLength` prop allows you to set the desired data length when calculating bar width. 
 
-This overrides the default calculation of `points.length`. Most useful in when dealing with time series, and rendering a known amount of time, but with various amounts of data so the bar widths can stay consistent across graphs.
+This overrides the default calculation of `points.length`. Usually used when rendering a static `x` domain and you want the bar widths to be the same across multiple graphs with various amounts of missing data.
 
 ### `children`
 

--- a/website/docs/cartesian/bar/bar.md
+++ b/website/docs/cartesian/bar/bar.md
@@ -58,9 +58,15 @@ The `roundedCorners` prop allows you to customize the roundedness of each corner
 - `bottomRight?: number`: Defines the radius of the bottom-right corner of the Bar. If not provided, the default is 0 (no rounding).
 - `bottomLeft?: number`: Defines the radius of the bottom-left corner of the Bar. If not provided, the default is 0 (no rounding).
 
+### `dataLength`
+
+An optional `dataLength` prop allows you to set the desired data length when calculating bar width. 
+
+This overrides the default calculation of `points.length`. Most useful in when dealing with time series, and rendering a known amount of time, but with various amounts of data so the bar widths can stay consistent across graphs.
+
 ### `children`
 
-A `children` pass-thru that will be rendered inside of the Skia `Path` element, useful if you'd like to make e.g. a gradient path.
+A `children` pass-thru that will be rendered inside the Skia `Path` element, useful if you'd like to make e.g. a gradient path.
 
 ### Paint properties
 

--- a/website/docs/cartesian/bar/use-bar-path.md
+++ b/website/docs/cartesian/bar/use-bar-path.md
@@ -58,6 +58,12 @@ A `ChartBounds` object needed to appropriately draw the bars. This generally com
 
 An optional `number` between 0 and 1 that represents what fraction of the horizontal space between the first and last bars should be "white space". Defaults to `0.2`. Use `0` for no gap between bars, and values closer to `1` to make bars increasingly narrow.
 
+### `dataLength`
+
+An optional `dataLength` prop allows you to set the desired data length when calculating bar width.
+
+This overrides the default calculation of `points.length`. Usually used when rendering a static `x` domain and you want the bar widths to be the same across multiple graphs with various amounts of missing data.
+
 ## Returns
 
 Returns an object with the following fields.


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/victory-native-xl/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds a `dataLength` prop to allow you to set a "known" data length, overriding the default `points.length` calculation when used with bar width.

The reason you might want this is due to having an incomplete data set, but wanting the bar width to match other graphs which have more/less data. Most useful when dealing with time series and rendering a static amount of time.

#### Type of Change


- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Create two bar graphs with a static domain. Pass the graphs data with two different lengths. Notice how the bar width is a different size.

Now enable the dataLength prop, and observe how the bar width is static. 

### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have run `yarn run check:code` and all checks pass
- [x] I have created a changeset for new features, patches, or major changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
