### PR TITLE
Fix missing prop for scatter radius width.

### DIFF
--- a/example/app/line-chart.tsx
+++ b/example/app/line-chart.tsx
@@ -103,6 +103,7 @@ export default function LineChartPage(props: { segment: string }) {
                 animate={{ type: "spring" }}
               />
               <Scatter
+                radius={scatterRadius}
                 points={points.sales}
                 animate={{ type: "spring" }}
                 color={colors.scatter!}


### PR DESCRIPTION
The prop to pass a dynamic `scatterRadius` to control the size got missed when we migrated to `<Scatter />` from the custom drawing. This fixes the demo app.