### PR TITLE
Fix typo in `useLinePath` documentation

### DIFF
--- a/website/docs/cartesian/line/use-line-path.md
+++ b/website/docs/cartesian/line/use-line-path.md
@@ -2,7 +2,7 @@
 
 The `useLinePath` hook takes a `PointsArray` input, as well as some options, and returns a Skia `SkPath` path object that represents the path for that line chart.
 
-## Exmaple
+## Example
 
 ```tsx
 import { CartesianChart, useLinePath, type PointsArray } from "victory-native";


### PR DESCRIPTION
### Description

Quick documentation typo fix.

#### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

None needed
