### PR TITLE
Fixe grid and frame `lineWidth` prop.

### DIFF
--- a/.changeset/few-rivers-retire.md
+++ b/.changeset/few-rivers-retire.md
@@ -1,0 +1,5 @@
+---
+"victory-native": patch
+---
+
+Fixed grid and frame lineWidth prop.

--- a/lib/src/cartesian/components/CartesianAxis.tsx
+++ b/lib/src/cartesian/components/CartesianAxis.tsx
@@ -58,7 +58,7 @@ export const CartesianAxis = <
         : lineColor) as Color,
       gridLineWidth: typeof lineWidth === "number" ? lineWidth : lineWidth.grid,
       frameLineWidth:
-        typeof lineWidth === "number" ? lineWidth : lineWidth.grid,
+        typeof lineWidth === "number" ? lineWidth : lineWidth.frame,
     } as const;
   }, [
     tickCount,
@@ -214,7 +214,10 @@ export const CartesianAxis = <
 
 CartesianAxis.defaultProps = {
   lineColor: "hsla(0, 0%, 0%, 0.25)",
-  lineWidth: { grid: StyleSheet.hairlineWidth, frame: 1 },
+  lineWidth: {
+    grid: StyleSheet.hairlineWidth,
+    frame: StyleSheet.hairlineWidth,
+  },
   tickCount: 5,
   labelOffset: { x: 2, y: 4 },
   axisSide: { x: "bottom", y: "left" },


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/victory-native-xl/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

Fixes the props not being correctly applied to the grid and frame.

Fixes #173 

Demonstration of the colors and props working:

<img width="391" alt="Screenshot 2023-12-21 at 3 29 20 PM" src="https://github.com/FormidableLabs/victory-native-xl/assets/1738349/68230212-3dbe-4717-916b-576a0e226ab8">
<img width="415" alt="Screenshot 2023-12-21 at 3 29 15 PM" src="https://github.com/FormidableLabs/victory-native-xl/assets/1738349/8081e7ef-8724-46c2-a8c0-f938ea43dcb4">
