### PR TITLE
add `domain` to `Cartesian` chart docs

### DIFF
--- a/website/docs/cartesian/cartesian-chart.md
+++ b/website/docs/cartesian/cartesian-chart.md
@@ -82,6 +82,12 @@ A `number` or an object of shape `{ left?: number; right?: number; top?: number;
 
 For example, passing `padding={{ left: 20, bottom: 20 }}` will add 20 Density Independent Pixels (DIPs) of space to the bottom and left of the chart, but have the chart "bleed" to the right and top. Passing `padding={20}` will add 20 DIPs of space to all sides.
 
+### `domain`
+
+An object of shape `{ x?: [number] | [number, number]; y?: [number] | [number, number] }` that can be specified to control the upper and lower bounds of each axis. It defaults to the min and max of each range respectively.
+
+For example, passing `domain={{y: [-10, 100]}}` will result in a y-axis with a lower bound of `-10` and an upper bound of `100`. For `domain={{x: [1, 4]}}`, will result in an x-axis contained within those bounds.
+
 ### `domainPadding`
 
 A `number` or an object of shape `{ left?: number; right?: number; top?: number; bottom?: number; }` that specifies that padding between the outer bounds of the _charting area_ (e.g. where the axes lie) and where chart elements will be plotted.


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

It looks like the docs were missing details about the `domain` prop available for the `Cartesian` chart.

Fixes #169 

