### PR TITLE
Gesture: Android bugfix + delay prop

### DIFF
--- a/.changeset/thin-glasses-glow.md
+++ b/.changeset/thin-glasses-glow.md
@@ -2,4 +2,4 @@
 "victory-native": patch
 ---
 
-Gesture fixes for Android. Added prop `gestureLongPressDelay`.
+Fixes interaction between gestures and scrolling for charts on Android. Added prop `gestureLongPressDelay` to `CartesianChart` .

--- a/.changeset/thin-glasses-glow.md
+++ b/.changeset/thin-glasses-glow.md
@@ -1,0 +1,5 @@
+---
+"victory-native": patch
+---
+
+Gesture fixes for Android. Added prop `gestureLongPressDelay`.

--- a/example/app/consts/routes.ts
+++ b/example/app/consts/routes.ts
@@ -79,6 +79,12 @@ if (__DEV__) {
       description: "Example showing missing data points.",
       path: "/missing-data",
     },
+    {
+      title: "Scrolling Charts with Gestures",
+      description:
+        "This page shows multiple charts with gestures inside a scrollview to ensure both platforms allow for this behavior.",
+      path: "/scrollview-charts",
+    },
   );
 }
 

--- a/example/app/scrollview-charts.tsx
+++ b/example/app/scrollview-charts.tsx
@@ -1,0 +1,88 @@
+import * as React from "react";
+import { StyleSheet, View, SafeAreaView } from "react-native";
+import { CartesianChart, Line, useChartPressState } from "victory-native";
+import { ScrollView } from "react-native-gesture-handler";
+import { Circle, useFont } from "@shopify/react-native-skia";
+import type { SharedValue } from "react-native-reanimated";
+import { InfoCard } from "example/components/InfoCard";
+import inter from "../assets/inter-medium.ttf";
+import { appColors } from "./consts/colors";
+
+const DATA = Array.from({ length: 31 }, (_, i) => ({
+  day: i,
+  highTmp: 40 + 30 * Math.random(),
+}));
+
+const BarChart = () => {
+  const font = useFont(inter, 12);
+  const { state, isActive } = useChartPressState({ x: 0, y: { highTmp: 0 } });
+  return (
+    <CartesianChart
+      data={DATA}
+      xKey="day"
+      yKeys={["highTmp"]}
+      axisOptions={{
+        font,
+      }}
+      chartPressState={state}
+    >
+      {({ points }) => (
+        <>
+          <Line points={points.highTmp} color="red" strokeWidth={3} />
+          {isActive && (
+            <ToolTip x={state.x.position} y={state.y.highTmp.position} />
+          )}
+        </>
+      )}
+    </CartesianChart>
+  );
+};
+
+export default function GettingStartedScreen() {
+  return (
+    <SafeAreaView style={styles.safeView}>
+      <ScrollView contentContainerStyle={styles.optionsScrollView}>
+        {Array.from({ length: 5 }, (_, i) => (
+          <React.Fragment key={i}>
+            <View style={styles.chart}>
+              <BarChart />
+            </View>
+            <InfoCard style={styles.card}>
+              Just a page with a number of charts nested within a ScrollView
+              from RNGH to test that scrolling and gestures still work as
+              intended.
+            </InfoCard>
+          </React.Fragment>
+        ))}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function ToolTip({ x, y }: { x: SharedValue<number>; y: SharedValue<number> }) {
+  return <Circle cx={x} cy={y} r={8} color="black" />;
+}
+
+const styles = StyleSheet.create({
+  safeView: {
+    flex: 1,
+    backgroundColor: appColors.viewBackground.light,
+    $dark: {
+      backgroundColor: appColors.viewBackground.dark,
+    },
+  },
+  optionsScrollView: {
+    padding: 32,
+    backgroundColor: appColors.cardBackground.light,
+    $dark: {
+      backgroundColor: appColors.cardBackground.dark,
+    },
+  },
+  chart: {
+    height: 300,
+    maxHeight: 400,
+  },
+  card: {
+    marginVertical: 22,
+  },
+});

--- a/website/docs/cartesian/cartesian-chart.md
+++ b/website/docs/cartesian/cartesian-chart.md
@@ -135,6 +135,10 @@ The `renderOutside` prop is identical to [the `children` prop](#children-require
 
 The `onChartBoundsChange` prop is a function of the shape `onChartBoundsChange?: (bounds: ChartBounds) => void;` that exposes the chart bounds, useful if you need access to the chart's bounds for your own custom drawing purposes.
 
+### `gestureLongPressDelay`
+
+The `gestureLongPressDelay` prop allows you to set the delay for the pan gesture. Default: `100`.
+
 ## Render Function Fields
 
 The `CartesianChart` `children` and `renderOutside` render functions both have a single argument that is an object with the following fields.

--- a/website/docs/cartesian/cartesian-chart.md
+++ b/website/docs/cartesian/cartesian-chart.md
@@ -137,7 +137,7 @@ The `onChartBoundsChange` prop is a function of the shape `onChartBoundsChange?:
 
 ### `gestureLongPressDelay`
 
-The `gestureLongPressDelay` prop allows you to set the delay for the pan gesture. Default: `100`.
+The `gestureLongPressDelay` prop allows you to set the delay in milliseconds before the pan gesture is activated. Defaults to `100`.
 
 ## Render Function Fields
 


### PR DESCRIPTION
### Description

This PR fixes and issue where on iOS the gestures had a delay that was not configurable, and on Android it didn't work, so both OSes had different behavior.
With this change, not only both OSes have the same behavior, but also adds two props to customize it, `gestureLongPressDelay` ~and `gestureBehavior`~.
- `gestureLongPressDelay` changes the pan delay, defaulting to 100 ms as before.
~- `gestureBehavior` allows you to handle taps too, not only long pressing. By default is `pan` as before.~

Fixes #182, #165 and #153 (and #163)

### Before
#### iOS

As expected, long pressing works. Scrolling works.

https://github.com/FormidableLabs/victory-native-xl/assets/3992081/eea4b094-49cc-4eb9-b40a-0bb0016c5edf

#### Android

Doesn't work as expected, it works by tapping and scrolling doesn't work.

https://github.com/FormidableLabs/victory-native-xl/assets/3992081/3487836c-10fc-43d2-b58e-46a9b42d00d1

### After (gestureBehavior: 'pan')

#### iOS

Works great as before.

https://github.com/FormidableLabs/victory-native-xl/assets/3992081/90cf22df-3b18-44c4-8c9d-185137dae9dc

#### Android

Same behavior as iOS.

https://github.com/FormidableLabs/victory-native-xl/assets/3992081/7761e20c-9c4c-4ca0-93c2-bc6fd80f8600

### After (gestureBehavior: 'tap')

#### iOS

Works by tapping, scroll works as expected.

https://github.com/FormidableLabs/victory-native-xl/assets/3992081/707d8118-1e14-4d59-9219-06df35232cbe

#### Android

Works by tapping, scroll works as expected.

https://github.com/FormidableLabs/victory-native-xl/assets/3992081/ae21b10f-9c70-44fc-932a-fd67c2bf9fbe

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Simulators and physical devices with iOS and Android, in an internal build tested by company employees.