### PR TITLE
Tap gesture with `gestureBehavior` prop

### DIFF
--- a/.changeset/clean-boxes-give.md
+++ b/.changeset/clean-boxes-give.md
@@ -1,0 +1,5 @@
+---
+"victory-native": patch
+---
+
+Add prop `gestureBehavior` to allow taps.

--- a/website/docs/cartesian/cartesian-chart.md
+++ b/website/docs/cartesian/cartesian-chart.md
@@ -139,6 +139,10 @@ The `onChartBoundsChange` prop is a function of the shape `onChartBoundsChange?:
 
 The `gestureLongPressDelay` prop allows you to set the delay in milliseconds before the pan gesture is activated. Defaults to `100`.
 
+### `gestureBehavior`
+
+The `gestureBehavior` prop has a type of `'pan' | 'tap'`. Allows you to set the behavior of the gesture. Default: `pan`.
+
 ## Render Function Fields
 
 The `CartesianChart` `children` and `renderOutside` render functions both have a single argument that is an object with the following fields.


### PR DESCRIPTION
### Description

This PR adds the prop `gestureBehavior` to allow tapping on the chart. By default is `pan` as before.

https://github.com/FormidableLabs/victory-native-xl/assets/3992081/ae21b10f-9c70-44fc-932a-fd67c2bf9fbe

#### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Simulators and physical devices with iOS and Android, in an internal build tested by company employees.