### PR TITLE
Update line chart example with label inputs

### DIFF
--- a/example/app/line-chart.tsx
+++ b/example/app/line-chart.tsx
@@ -1,7 +1,13 @@
 import { useFont } from "@shopify/react-native-skia";
 import * as React from "react";
 import { useState } from "react";
-import { SafeAreaView, ScrollView, StyleSheet, View } from "react-native";
+import {
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  TextInput,
+  View,
+} from "react-native";
 import {
   CartesianChart,
   type CurveType,
@@ -53,6 +59,8 @@ export default function LineChartPage(props: { segment: string }) {
       colors,
       domainPadding,
       curveType,
+      customXLabel,
+      customYLabel,
     },
     dispatch,
   ] = React.useReducer(optionsReducer, {
@@ -88,6 +96,12 @@ export default function LineChartPage(props: { segment: string }) {
             labelPosition: {
               x: xAxisLabelPosition,
               y: yAxisLabelPosition,
+            },
+            formatXLabel: (value) => {
+              return customXLabel ? `${value} ${customXLabel}` : `${value}`;
+            },
+            formatYLabel: (value) => {
+              return customYLabel ? `${value} ${customYLabel}` : `${value}`;
             },
           }}
           data={data}
@@ -143,6 +157,17 @@ export default function LineChartPage(props: { segment: string }) {
             title="Add Point"
           />
         </View>
+
+        <View>
+          <TextInput
+            placeholder="X Label Text"
+            value={customXLabel}
+            onChangeText={(val) =>
+              dispatch({ type: "SET_X_LABEL", payload: val })
+            }
+          />
+        </View>
+
         <InputSegment<CurveType>
           label="Curve Type"
           onChange={(val) => dispatch({ type: "SET_CURVE_TYPE", payload: val })}

--- a/example/app/line-chart.tsx
+++ b/example/app/line-chart.tsx
@@ -25,6 +25,7 @@ import {
   optionsReducer,
 } from "example/hooks/useOptionsReducer";
 import { InputColor } from "example/components/InputColor";
+import { InputText } from "example/components/InputText";
 import inter from "../assets/inter-medium.ttf";
 import { appColors } from "./consts/colors";
 import { Button } from "../components/Button";
@@ -158,16 +159,6 @@ export default function LineChartPage(props: { segment: string }) {
           />
         </View>
 
-        <View>
-          <TextInput
-            placeholder="X Label Text"
-            value={customXLabel}
-            onChangeText={(val) =>
-              dispatch({ type: "SET_X_LABEL", payload: val })
-            }
-          />
-        </View>
-
         <InputSegment<CurveType>
           label="Curve Type"
           onChange={(val) => dispatch({ type: "SET_CURVE_TYPE", payload: val })}
@@ -235,6 +226,28 @@ export default function LineChartPage(props: { segment: string }) {
             dispatch({ type: "SET_COLORS", payload: { line: val } })
           }
         />
+
+        <View style={{ flexDirection: "row" }}>
+          <InputText
+            label="X Label Text"
+            placeholder="Label text here..."
+            value={customXLabel}
+            onChangeText={(val) =>
+              dispatch({ type: "SET_X_LABEL", payload: val })
+            }
+          />
+          {/** Spacer */}
+          <View style={{ width: 10 }} />
+          <InputText
+            label="Y Label Text"
+            placeholder="Label text here..."
+            value={customYLabel}
+            onChangeText={(val) =>
+              dispatch({ type: "SET_Y_LABEL", payload: val })
+            }
+          />
+        </View>
+
         <InputSlider
           label="Axis Label Font Size"
           maxValue={24}

--- a/example/app/line-chart.tsx
+++ b/example/app/line-chart.tsx
@@ -1,13 +1,7 @@
 import { useFont } from "@shopify/react-native-skia";
 import * as React from "react";
 import { useState } from "react";
-import {
-  SafeAreaView,
-  ScrollView,
-  StyleSheet,
-  TextInput,
-  View,
-} from "react-native";
+import { SafeAreaView, ScrollView, StyleSheet, View } from "react-native";
 import {
   CartesianChart,
   type CurveType,

--- a/example/components/InputText.tsx
+++ b/example/components/InputText.tsx
@@ -1,10 +1,33 @@
-import React from "react";
-import { TextInput } from "react-native";
+import React, { type ComponentProps } from "react";
+import { StyleSheet, Text, TextInput, View } from "react-native";
 
-export const InputText = () => {
+type Props = { label: string } & ComponentProps<typeof TextInput>;
+
+export const InputText = ({ label, ...props }: Props) => {
   return (
-    <>
-      <TextInput />
-    </>
+    <View style={styles.container}>
+      <Text style={styles.labelStyles}>{label}</Text>
+      <TextInput style={styles.inputStyles} {...props} />
+    </View>
   );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    paddingVertical: 10,
+    width: "48%",
+  },
+  inputStyles: {
+    borderRadius: 5,
+    borderWidth: 2,
+    borderColor: "lightgray",
+    fontSize: 16,
+    paddingVertical: 10,
+    paddingHorizontal: 15,
+    width: "100%",
+  },
+  labelStyles: {
+    fontWeight: "bold",
+    paddingBottom: 10,
+  },
+});

--- a/example/components/InputText.tsx
+++ b/example/components/InputText.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { TextInput } from "react-native";
+
+export const InputText = () => {
+  return (
+    <>
+      <TextInput />
+    </>
+  );
+};

--- a/example/hooks/useOptionsReducer.ts
+++ b/example/hooks/useOptionsReducer.ts
@@ -17,6 +17,8 @@ type State = {
   colors: Record<string, string>;
   domainPadding: number;
   curveType: CurveType;
+  customXLabel: string | undefined;
+  customYLabel: string | undefined;
 };
 
 type Action =
@@ -34,7 +36,9 @@ type Action =
   | { type: "SET_Y_AXIS_LABEL_POSITION"; payload: AxisLabelPosition }
   | { type: "SET_COLORS"; payload: Record<string, string> }
   | { type: "SET_DOMAIN_PADDING"; payload: number }
-  | { type: "SET_CURVE_TYPE"; payload: CurveType };
+  | { type: "SET_CURVE_TYPE"; payload: CurveType }
+  | { type: "SET_X_LABEL"; payload: string }
+  | { type: "SET_Y_LABEL"; payload: string };
 
 export const optionsReducer = (state: State, action: Action): State => {
   switch (action.type) {
@@ -68,6 +72,10 @@ export const optionsReducer = (state: State, action: Action): State => {
       return { ...state, domainPadding: action.payload };
     case "SET_CURVE_TYPE":
       return { ...state, curveType: action.payload };
+    case "SET_X_LABEL":
+      return { ...state, customXLabel: action.payload };
+    case "SET_Y_LABEL":
+      return { ...state, customYLabel: action.payload };
 
     default:
       throw new Error(`Unhandled action type`);
@@ -90,4 +98,6 @@ export const optionsInitialState: State = {
   colors: {},
   domainPadding: 0,
   curveType: "linear",
+  customXLabel: undefined,
+  customYLabel: undefined,
 };


### PR DESCRIPTION
### Description

This PR is an update to the Line Chart example screen to include text inputs for X/Y labels. This change does not resolve a specific issue, but was added to confirm custom X and Y labels weren't contributing to the issues mentioned in this [issue](https://github.com/FormidableLabs/victory-native-xl/issues/152) 

