### PR TITLE
Fix invalid syntax in Documentation of BarChart -  basic-bar-chart.md

### DIFF
--- a/website/docs/cartesian/guides/basic-bar-chart.md
+++ b/website/docs/cartesian/guides/basic-bar-chart.md
@@ -75,7 +75,7 @@ This guide will show you how to create this bar chart with some customization li
         xKey="month"
         yKeys={["listenCount"]}
         // 👇 Add domain padding to the chart to prevent the first and last bar from being cut off.
-        domainPadding={{ left: 50, right: 50, top: 30 }}}
+        domainPadding={{ left: 50, right: 50, top: 30 }}
         axisOptions={{
           /**
            * 👇 Pass the font object to the axisOptions.


### PR DESCRIPTION
### Description

Change invalid syntax from }}} to }} 



PS:

Sorry most of the checklist is relevant to code changes and this only one char in the documentation. 
Not sure if the rules applies for this fix.