### PR TITLE
fix: always hide tooltip onEnd of cartesian pangesture

### DIFF
--- a/.changeset/empty-tigers-walk.md
+++ b/.changeset/empty-tigers-walk.md
@@ -1,0 +1,5 @@
+---
+"victory-native": patch
+---
+
+fix: add onEnd callback for cartesian pangesture

--- a/lib/src/cartesian/CartesianChart.tsx
+++ b/lib/src/cartesian/CartesianChart.tsx
@@ -275,6 +275,18 @@ export function CartesianChart<
       }
     })
     /**
+     * Once the gesture ends, ensure all active values are falsified.
+     */
+    .onEnd(() => {
+      const vals = activePressSharedValues || [];
+      // Set active state to false for all vals
+      for (const val of vals) {
+        if (val) {
+          val.isActive.value = false;
+        }
+      }
+    })
+    /**
      * Activate after a long press, which helps with preventing all touch hijacking.
      * This is important if this chart is inside of some sort of scrollable container.
      */


### PR DESCRIPTION
### Description

Ensures tooltip disappears once the user stops panning the chart. This should resolve #213 @zibs.
By wiping the active values array on PanGesture `.onEnd` the tooltip is forced to hide when your finger stops gesturing.

Fixes #213 

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested locally as a package change in node_modules in my app.

### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have run `yarn run check:code` and all checks pass
- [x] I have created a changeset for new features, patches, or major changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
