### PR TITLE
Replace instances of 'getTextWidth' with 'measureText'

### DIFF
--- a/.changeset/serious-yaks-visit.md
+++ b/.changeset/serious-yaks-visit.md
@@ -1,0 +1,6 @@
+---
+"example": patch
+"victory-native": patch
+---
+
+Replace getTextWidth with measureText

--- a/example/app/stock-price.tsx
+++ b/example/app/stock-price.tsx
@@ -380,7 +380,7 @@ const ActiveValueIndicator = ({
     () => "$" + activeValue.value.toFixed(2),
   );
   const activeValueWidth = useDerivedValue(
-    () => font?.getTextWidth(activeValueDisplay.value) || 0,
+    () => font?.measureText(activeValueDisplay.value).width || 0,
   );
   const activeValueX = useDerivedValue(
     () => xPosition.value - activeValueWidth.value / 2,

--- a/lib/src/cartesian/components/CartesianAxis.tsx
+++ b/lib/src/cartesian/components/CartesianAxis.tsx
@@ -125,7 +125,7 @@ export const CartesianAxis = <
     : yScale.ticks(yTicks);
   const yAxisNodes = yTicksNormalized.map((tick) => {
     const contentY = formatYLabel(tick as never);
-    const labelWidth = font?.getTextWidth?.(contentY) ?? 0;
+    const labelWidth = font?.measureText?.(contentY).width ?? 0;
     const labelY = yScale(tick) + fontSize / 3;
     const labelX = (() => {
       // left, outset
@@ -178,7 +178,7 @@ export const CartesianAxis = <
   const xAxisNodes = xTicksNormalized.map((tick) => {
     const val = isNumericalData ? tick : ix[tick];
     const contentX = formatXLabel(val as never);
-    const labelWidth = font?.getTextWidth?.(contentX) ?? 0;
+    const labelWidth = font?.measureText?.(contentX).width ?? 0;
     const labelX = xScale(tick) - (labelWidth ?? 0) / 2;
     const canFitLabelContent =
       yAxisPosition === "left" ? labelX + labelWidth < x2r : x1r < labelX;

--- a/lib/src/cartesian/utils/transformInputData.ts
+++ b/lib/src/cartesian/utils/transformInputData.ts
@@ -183,7 +183,7 @@ export const transformInputData = <
   // Else, we find min / max of y values across all yKeys, and use that for y range instead.
   const ixMin = asNumber(domain?.x?.[0] ?? tickDomainsX?.[0] ?? ixNum.at(0)),
     ixMax = asNumber(domain?.x?.[1] ?? tickDomainsX?.[1] ?? ixNum.at(-1));
-  const topYLabelWidth = axisOptions?.font?.getTextWidth(topYLabel) ?? 0;
+  const topYLabelWidth = axisOptions?.font?.measureText(topYLabel).width ?? 0;
   // Determine our x-output range based on yAxis/label options
   const oRange: [number, number] = (() => {
     const yTickCount =


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/victory-native-xl/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description



Fixes #282 by replacing all instances. This is because `getTextWidth` has been deprecated most likely due to buggy behavior when measuring text, and especially so when measuring number width which is relevant when calculating axis placement and padding. 

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [ ] Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?

tested on example app. `measureText.width` is a drop in replacement


