### PR TITLE
Fix yLabel width calculation to better align x-scale

### DIFF
--- a/.changeset/cuddly-bikes-decide.md
+++ b/.changeset/cuddly-bikes-decide.md
@@ -1,0 +1,6 @@
+---
+"example": patch
+"victory-native": patch
+---
+
+Fix yLabel width calculation to better align x-scale

--- a/example/app/axis-configuration.tsx
+++ b/example/app/axis-configuration.tsx
@@ -1,0 +1,346 @@
+import { useFont } from "@shopify/react-native-skia";
+import * as React from "react";
+import { useMemo } from "react";
+import { SafeAreaView, ScrollView, StyleSheet, View } from "react-native";
+import {
+  CartesianChart,
+  Line,
+  Scatter,
+  type XAxisSide,
+  type YAxisSide,
+} from "victory-native";
+import type { AxisLabelPosition } from "lib/src/types";
+import { useDarkMode } from "react-native-dark";
+import { InputSlider } from "example/components/InputSlider";
+import { InputSegment } from "example/components/InputSegment";
+import {
+  optionsInitialState,
+  optionsReducer,
+} from "example/hooks/useOptionsReducer";
+import { InputColor } from "example/components/InputColor";
+import { InputText } from "example/components/InputText";
+import inter from "../assets/inter-medium.ttf";
+import { appColors } from "./consts/colors";
+import { InfoCard } from "../components/InfoCard";
+import { descriptionForRoute } from "./consts/routes";
+
+const parseTickValues = (tickString?: string) =>
+  tickString
+    ?.split(",")
+    .map((v) => parseFloat(v))
+    .filter((v) => !isNaN(v));
+
+const DATA = (ticksX: number[], ticksY: number[]) => {
+  const maxY = Math.max(...ticksY);
+  const minY = Math.min(...ticksY);
+  const maxX = Math.max(...ticksX);
+  const minX = Math.min(...ticksX);
+  const dX = maxX - minX;
+  const dY = maxY - minY;
+
+  return Array.from({ length: 10 }, (_, index) => ({
+    day: minX + (dX * index) / 10,
+    sales: Math.random() * dY + minY,
+  }));
+};
+
+export default function AxisConfiguration(props: { segment: string }) {
+  const description = descriptionForRoute(props.segment);
+  const isDark = useDarkMode();
+  const [
+    {
+      fontSize,
+      chartPadding,
+      strokeWidth,
+      xAxisSide,
+      yAxisSide,
+      xLabelOffset,
+      yLabelOffset,
+      xTickCount,
+      yTickCount,
+      xAxisLabelPosition,
+      yAxisLabelPosition,
+      scatterRadius,
+      colors,
+      domainPadding,
+      curveType,
+      customXLabel,
+      customYLabel,
+      xAxisValues,
+      yAxisValues,
+    },
+    dispatch,
+  ] = React.useReducer(optionsReducer, {
+    ...optionsInitialState,
+    domainPadding: 10,
+    chartPadding: 0,
+    strokeWidth: 2,
+    xAxisValues: "0,2,4,6,8",
+    yAxisValues: "-1,0,1,2,4,6,8",
+    colors: {
+      stroke: isDark ? "#fafafa" : "#71717a",
+      xLine: isDark ? "#71717a" : "#ffffff",
+      yLine: isDark ? "#aabbcc" : "#ddfa55",
+      frameLine: isDark ? "#444" : "#aaa",
+      xLabel: isDark ? appColors.text.dark : appColors.text.light,
+      yLabel: isDark ? appColors.text.dark : appColors.text.light,
+      scatter: "#a78bfa",
+    },
+  });
+  const font = useFont(inter, fontSize);
+  const ticksX = useMemo(
+    () => parseTickValues(xAxisValues) ?? [0, 10],
+    [xAxisValues],
+  );
+  const ticksY = useMemo(
+    () => parseTickValues(yAxisValues) ?? [0, 10],
+    [yAxisValues],
+  );
+
+  const data = useMemo(() => DATA(ticksX, ticksY), [xAxisValues, yAxisValues]);
+
+  return (
+    <SafeAreaView style={styles.safeView}>
+      <View style={styles.chart}>
+        <CartesianChart
+          xKey="day"
+          padding={chartPadding}
+          yKeys={["sales"]}
+          axisOptions={{
+            font,
+            lineWidth: { grid: { x: 0, y: 2 }, frame: 0 },
+            lineColor: {
+              grid: {
+                x: colors.xLine!,
+                y: colors.yLine!,
+              },
+              frame: colors.frameLine!,
+            },
+            labelColor: { x: colors.xLabel!, y: colors.yLabel! },
+            labelOffset: { x: xLabelOffset, y: yLabelOffset },
+            tickValues: {
+              x: ticksX,
+              y: ticksY,
+            },
+            tickCount: { x: xTickCount, y: yTickCount },
+            axisSide: { x: xAxisSide, y: yAxisSide },
+            labelPosition: {
+              x: xAxisLabelPosition,
+              y: yAxisLabelPosition,
+            },
+            formatXLabel: (value) => {
+              return customXLabel ? `${value} ${customXLabel}` : `${value}`;
+            },
+            formatYLabel: (value) => {
+              return customYLabel ? `${value} ${customYLabel}` : `${value}`;
+            },
+          }}
+          data={data}
+          domainPadding={domainPadding}
+        >
+          {({ points }) => (
+            <>
+              <Line
+                points={points.sales}
+                curveType={curveType}
+                color={colors.stroke!}
+                strokeWidth={strokeWidth}
+                animate={{ type: "spring" }}
+              />
+              <Scatter
+                radius={scatterRadius}
+                points={points.sales}
+                animate={{ type: "spring" }}
+                color={colors.scatter!}
+              />
+            </>
+          )}
+        </CartesianChart>
+      </View>
+      <ScrollView
+        style={styles.optionsScrollView}
+        contentContainerStyle={styles.options}
+      >
+        <InfoCard>{description}</InfoCard>
+        <View style={{ flexDirection: "row" }}>
+          <InputText
+            label="X Tick Values"
+            placeholder="Comma separated"
+            value={xAxisValues}
+            onChangeText={(val) =>
+              dispatch({
+                type: "SET_X_AXIS_VALUES",
+                payload: val,
+              })
+            }
+          />
+          {/** Spacer */}
+          <View style={{ width: 10 }} />
+          <InputText
+            label="Y Tick Values"
+            placeholder="Comma separated"
+            value={yAxisValues}
+            onChangeText={(val) =>
+              dispatch({
+                type: "SET_Y_AXIS_VALUES",
+                payload: val,
+              })
+            }
+          />
+        </View>
+        <View style={{ flexDirection: "row" }}>
+          <InputText
+            label="X Label Text"
+            placeholder="Label text here..."
+            value={customXLabel}
+            onChangeText={(val) =>
+              dispatch({ type: "SET_X_LABEL", payload: val })
+            }
+          />
+          {/** Spacer */}
+          <View style={{ width: 10 }} />
+          <InputText
+            label="Y Label Text"
+            placeholder="Label text here..."
+            value={customYLabel}
+            onChangeText={(val) =>
+              dispatch({ type: "SET_Y_LABEL", payload: val })
+            }
+          />
+        </View>
+
+        <InputSlider
+          label="Chart Padding"
+          maxValue={20}
+          minValue={0}
+          step={1}
+          value={chartPadding}
+          onChange={(val) =>
+            dispatch({ type: "SET_CHART_PADDING", payload: val })
+          }
+        />
+        <InputSlider
+          label="Axis Label Font Size"
+          maxValue={24}
+          minValue={8}
+          step={1}
+          value={fontSize}
+          onChange={(val) => dispatch({ type: "SET_FONT_SIZE", payload: val })}
+        />
+        <InputSlider
+          label="Number of X-axis Grid Lines"
+          maxValue={15}
+          minValue={0}
+          step={5}
+          value={xTickCount}
+          onChange={(val) =>
+            dispatch({ type: "SET_X_TICK_COUNT", payload: val })
+          }
+        />
+        <InputSlider
+          label="X-axis Label Offset"
+          maxValue={12}
+          minValue={0}
+          step={1}
+          value={xLabelOffset}
+          onChange={(val) =>
+            dispatch({ type: "SET_X_LABEL_OFFSET", payload: val })
+          }
+        />
+        <InputSegment<XAxisSide>
+          label="X Axis side"
+          onChange={(val) =>
+            dispatch({ type: "SET_X_AXIS_SIDE", payload: val })
+          }
+          value={xAxisSide}
+          values={["top", "bottom"]}
+        />
+
+        <InputSegment<AxisLabelPosition>
+          label="X Axis Label position"
+          onChange={(val) =>
+            dispatch({ type: "SET_X_AXIS_LABEL_POSITION", payload: val })
+          }
+          value={xAxisLabelPosition}
+          values={["inset", "outset"]}
+        />
+        <InputColor
+          label="X-axis Label Color"
+          color={colors.xLabel}
+          onChange={(val) =>
+            dispatch({ type: "SET_COLORS", payload: { xLabel: val } })
+          }
+        />
+        <InputSlider
+          label="Number of Y-axis Grid Lines"
+          maxValue={20}
+          minValue={0}
+          step={5}
+          value={yTickCount}
+          onChange={(val) =>
+            dispatch({ type: "SET_Y_TICK_COUNT", payload: val })
+          }
+        />
+        <InputSlider
+          label="Y-axis Label Offset"
+          maxValue={12}
+          minValue={0}
+          step={1}
+          value={yLabelOffset}
+          onChange={(val) =>
+            dispatch({ type: "SET_Y_LABEL_OFFSET", payload: val })
+          }
+        />
+        <InputSegment<AxisLabelPosition>
+          label="Y Axis Label position"
+          onChange={(val) =>
+            dispatch({ type: "SET_Y_AXIS_LABEL_POSITION", payload: val })
+          }
+          value={yAxisLabelPosition}
+          values={["inset", "outset"]}
+        />
+        <InputSegment<YAxisSide>
+          label="Y Axis side"
+          onChange={(val) =>
+            dispatch({ type: "SET_Y_AXIS_SIDE", payload: val })
+          }
+          value={yAxisSide}
+          values={["left", "right"]}
+        />
+        <InputColor
+          label="Y-axis Label Color"
+          color={colors.yLabel}
+          onChange={(val) =>
+            dispatch({ type: "SET_COLORS", payload: { yLabel: val } })
+          }
+        />
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeView: {
+    flex: 1,
+    backgroundColor: appColors.viewBackground.light,
+    $dark: {
+      backgroundColor: appColors.viewBackground.dark,
+    },
+  },
+  chart: {
+    flex: 1,
+  },
+  optionsScrollView: {
+    flex: 0.5,
+    backgroundColor: appColors.cardBackground.light,
+    $dark: {
+      backgroundColor: appColors.cardBackground.dark,
+    },
+  },
+  options: {
+    paddingHorizontal: 20,
+    paddingVertical: 15,
+    alignItems: "flex-start",
+    justifyContent: "flex-start",
+  },
+});

--- a/example/app/axis-configuration.tsx
+++ b/example/app/axis-configuration.tsx
@@ -97,7 +97,7 @@ export default function AxisConfiguration(props: { segment: string }) {
     [yAxisValues],
   );
 
-  const data = useMemo(() => DATA(ticksX, ticksY), [xAxisValues, yAxisValues]);
+  const data = useMemo(() => DATA(ticksX, ticksY), [ticksX, ticksY]);
 
   return (
     <SafeAreaView style={styles.safeView}>

--- a/example/app/consts/routes.ts
+++ b/example/app/consts/routes.ts
@@ -59,6 +59,12 @@ export const ChartRoutes: {
     path: "/ordinal-data",
   },
   {
+    title: "Axis Configuration",
+    description:
+      "This shows off the various ways to configure custom axis rendering.",
+    path: "/axis-configuration",
+  },
+  {
     title: "Custom Shaders",
     description:
       "This chart showcases using custom shaders from Skia, leveraging shader uniforms derived from Reanimated shared values.",

--- a/example/hooks/useOptionsReducer.ts
+++ b/example/hooks/useOptionsReducer.ts
@@ -19,6 +19,8 @@ type State = {
   curveType: CurveType;
   customXLabel: string | undefined;
   customYLabel: string | undefined;
+  xAxisValues: string | undefined;
+  yAxisValues: string | undefined;
 };
 
 type Action =
@@ -38,7 +40,9 @@ type Action =
   | { type: "SET_DOMAIN_PADDING"; payload: number }
   | { type: "SET_CURVE_TYPE"; payload: CurveType }
   | { type: "SET_X_LABEL"; payload: string }
-  | { type: "SET_Y_LABEL"; payload: string };
+  | { type: "SET_Y_LABEL"; payload: string }
+  | { type: "SET_X_AXIS_VALUES"; payload: string | undefined }
+  | { type: "SET_Y_AXIS_VALUES"; payload: string | undefined };
 
 export const optionsReducer = (state: State, action: Action): State => {
   switch (action.type) {
@@ -76,6 +80,10 @@ export const optionsReducer = (state: State, action: Action): State => {
       return { ...state, customXLabel: action.payload };
     case "SET_Y_LABEL":
       return { ...state, customYLabel: action.payload };
+    case "SET_X_AXIS_VALUES":
+      return { ...state, xAxisValues: action.payload };
+    case "SET_Y_AXIS_VALUES":
+      return { ...state, yAxisValues: action.payload };
 
     default:
       throw new Error(`Unhandled action type`);
@@ -100,4 +108,6 @@ export const optionsInitialState: State = {
   curveType: "linear",
   customXLabel: undefined,
   customYLabel: undefined,
+  xAxisValues: undefined,
+  yAxisValues: undefined,
 };

--- a/lib/src/cartesian/CartesianChart.tsx
+++ b/lib/src/cartesian/CartesianChart.tsx
@@ -93,48 +93,69 @@ export function CartesianChart<
     ),
   });
 
-  const { xScale, yScale, chartBounds, isNumericalData, _tData } =
-    React.useMemo(() => {
-      const { xScale, yScale, isNumericalData, ..._tData } = transformInputData(
-        {
-          data,
-          xKey,
-          yKeys,
-          axisOptions: axisOptions
-            ? Object.assign({}, CartesianAxisDefaultProps, axisOptions)
-            : undefined,
-          outputWindow: {
-            xMin: valueFromSidedNumber(padding, "left"),
-            xMax: size.width - valueFromSidedNumber(padding, "right"),
-            yMin: valueFromSidedNumber(padding, "top"),
-            yMax: size.height - valueFromSidedNumber(padding, "bottom"),
-          },
-          domain,
-          domainPadding,
-        },
-      );
-      tData.value = _tData;
-
-      const chartBounds = {
-        left: xScale(xScale.domain().at(0) || 0),
-        right: xScale(xScale.domain().at(-1) || 0),
-        top: yScale(yScale.domain().at(0) || 0),
-        bottom: yScale(yScale.domain().at(-1) || 0),
-      };
-
-      return { tData, xScale, yScale, chartBounds, isNumericalData, _tData };
-    }, [
+  const {
+    xTicksNormalized,
+    yTicksNormalized,
+    xScale,
+    yScale,
+    chartBounds,
+    isNumericalData,
+    _tData,
+  } = React.useMemo(() => {
+    const {
+      xScale,
+      yScale,
+      isNumericalData,
+      xTicksNormalized,
+      yTicksNormalized,
+      ..._tData
+    } = transformInputData({
       data,
       xKey,
       yKeys,
-      axisOptions,
-      padding,
-      size.width,
-      size.height,
+      axisOptions: axisOptions
+        ? Object.assign({}, CartesianAxisDefaultProps, axisOptions)
+        : undefined,
+      outputWindow: {
+        xMin: valueFromSidedNumber(padding, "left"),
+        xMax: size.width - valueFromSidedNumber(padding, "right"),
+        yMin: valueFromSidedNumber(padding, "top"),
+        yMax: size.height - valueFromSidedNumber(padding, "bottom"),
+      },
       domain,
       domainPadding,
+    });
+    tData.value = _tData;
+
+    const chartBounds = {
+      left: xScale(xScale.domain().at(0) || 0),
+      right: xScale(xScale.domain().at(-1) || 0),
+      top: yScale(yScale.domain().at(0) || 0),
+      bottom: yScale(yScale.domain().at(-1) || 0),
+    };
+
+    return {
+      xTicksNormalized,
+      yTicksNormalized,
       tData,
-    ]);
+      xScale,
+      yScale,
+      chartBounds,
+      isNumericalData,
+      _tData,
+    };
+  }, [
+    data,
+    xKey,
+    yKeys,
+    axisOptions,
+    padding,
+    size.width,
+    size.height,
+    domain,
+    domainPadding,
+    tData,
+  ]);
 
   /**
    * Pan gesture handling
@@ -356,6 +377,8 @@ export function CartesianChart<
                 xScale,
                 yScale,
                 isNumericalData,
+                xTicksNormalized,
+                yTicksNormalized,
                 ix: _tData.ix,
               }}
             />

--- a/lib/src/cartesian/components/CartesianAxis.tsx
+++ b/lib/src/cartesian/components/CartesianAxis.tsx
@@ -15,14 +15,14 @@ import type {
   AxisProps,
   InputFields,
 } from "../../types";
+import { DEFAULT_TICK_COUNT } from "../../utils/tickHelpers";
 
 export const CartesianAxis = <
   RawData extends Record<string, unknown>,
   XK extends keyof InputFields<RawData>,
   YK extends keyof NumericalFields<RawData>,
 >({
-  tickCount = 5,
-  tickValues,
+  tickCount = DEFAULT_TICK_COUNT,
   xTicksNormalized,
   yTicksNormalized,
   labelPosition = "outset",
@@ -84,7 +84,6 @@ export const CartesianAxis = <
           : lineWidth,
     } as const;
   }, [
-    tickValues,
     tickCount,
     labelOffset,
     axisSide.x,

--- a/lib/src/cartesian/components/CartesianAxis.tsx
+++ b/lib/src/cartesian/components/CartesianAxis.tsx
@@ -8,7 +8,6 @@ import {
   type Color,
 } from "@shopify/react-native-skia";
 import { StyleSheet } from "react-native";
-import { downsampleTicks } from "../../utils/tickHelpers";
 import type {
   ValueOf,
   NumericalFields,
@@ -24,6 +23,8 @@ export const CartesianAxis = <
 >({
   tickCount = 5,
   tickValues,
+  xTicksNormalized,
+  yTicksNormalized,
   labelPosition = "outset",
   labelOffset = { x: 2, y: 4 },
   axisSide = { x: "bottom", y: "left" },
@@ -42,8 +43,6 @@ export const CartesianAxis = <
     return {
       xTicks: typeof tickCount === "number" ? tickCount : tickCount.x,
       yTicks: typeof tickCount === "number" ? tickCount : tickCount.y,
-      xTickValues: Array.isArray(tickValues) ? tickValues : tickValues?.x,
-      yTickValues: Array.isArray(tickValues) ? tickValues : tickValues?.y,
       xLabelOffset:
         typeof labelOffset === "number" ? labelOffset : labelOffset.x,
       yLabelOffset:
@@ -98,8 +97,6 @@ export const CartesianAxis = <
   const {
     xTicks,
     yTicks,
-    xTickValues,
-    yTickValues,
     xAxisPosition,
     yAxisPosition,
     xLabelPosition,
@@ -119,10 +116,6 @@ export const CartesianAxis = <
   const [x1r = 0, x2r = 0] = xScale.range();
   const fontSize = font?.getSize() ?? 0;
 
-  // Normalize yTicks values either via the d3 scaleLinear ticks() function or our custom downSample function
-  const yTicksNormalized = yTickValues
-    ? downsampleTicks(yTickValues, yTicks)
-    : yScale.ticks(yTicks);
   const yAxisNodes = yTicksNormalized.map((tick) => {
     const contentY = formatYLabel(tick as never);
     const labelWidth = font?.measureText?.(contentY).width ?? 0;
@@ -171,10 +164,6 @@ export const CartesianAxis = <
     );
   });
 
-  // Normalize xTicks values either via the d3 scaleLinear ticks() function or our custom downSample function
-  const xTicksNormalized = xTickValues
-    ? downsampleTicks(xTickValues, xTicks)
-    : xScale.ticks(xTicks);
   const xAxisNodes = xTicksNormalized.map((tick) => {
     const val = isNumericalData ? tick : ix[tick];
     const contentX = formatXLabel(val as never);

--- a/lib/src/cartesian/utils/transformInputData.ts
+++ b/lib/src/cartesian/utils/transformInputData.ts
@@ -1,5 +1,5 @@
 import { type ScaleLinear } from "d3-scale";
-import { downsampleTicks, getDomainFromTicks } from "../../utils/tickHelpers";
+import { DEFAULT_TICK_COUNT, downsampleTicks, getDomainFromTicks } from "../../utils/tickHelpers";
 import type {
   AxisProps,
   NumericalFields,
@@ -55,7 +55,7 @@ export const transformInputData = <
 } => {
   const data = [..._data];
   const tickValues = axisOptions?.tickValues;
-  const tickCount = axisOptions?.tickCount ?? 5;
+  const tickCount = axisOptions?.tickCount ?? DEFAULT_TICK_COUNT;
 
   const xTickValues =
     tickValues && typeof tickValues === "object" && "x" in tickValues

--- a/lib/src/cartesian/utils/transformInputData.ts
+++ b/lib/src/cartesian/utils/transformInputData.ts
@@ -1,5 +1,9 @@
 import { type ScaleLinear } from "d3-scale";
-import { DEFAULT_TICK_COUNT, downsampleTicks, getDomainFromTicks } from "../../utils/tickHelpers";
+import {
+  DEFAULT_TICK_COUNT,
+  downsampleTicks,
+  getDomainFromTicks,
+} from "../../utils/tickHelpers";
 import type {
   AxisProps,
   NumericalFields,

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -98,6 +98,8 @@ export type AxisProps<
   XK extends keyof InputFields<RawData>,
   YK extends keyof NumericalFields<RawData>,
 > = {
+  xTicksNormalized: number[];
+  yTicksNormalized: number[];
   xScale: ScaleLinear<number, number, never>;
   yScale: ScaleLinear<number, number, never>;
   font?: SkFont | null;

--- a/lib/src/utils/tickHelpers.ts
+++ b/lib/src/utils/tickHelpers.ts
@@ -1,3 +1,5 @@
+export const DEFAULT_TICK_COUNT = 5;
+
 function coerceNumArray<T>(collection: Array<T>) {
   return collection.map((item, idx) =>
     Number.isNaN(Number(item)) ? idx : (item as number),
@@ -33,6 +35,7 @@ const getMinValue = (arr: Array<number>): number => {
 const getMaxValue = (arr: Array<number>): number => {
   return Math.max(...arr);
 };
+
 
 export const getDomainFromTicks = (tickValues: number[] | undefined) => {
   // Check if undefined OR if its not an array of numbers

--- a/lib/src/utils/tickHelpers.ts
+++ b/lib/src/utils/tickHelpers.ts
@@ -36,7 +36,6 @@ const getMaxValue = (arr: Array<number>): number => {
   return Math.max(...arr);
 };
 
-
 export const getDomainFromTicks = (tickValues: number[] | undefined) => {
   // Check if undefined OR if its not an array of numbers
   if (!tickValues) return;


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/victory-native-xl/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #274 

(builds off of #290, can update pr once that gets merged in)

Basically moves the `yTicksNormalized` calculation to `transformInputData` so that we know what all the ticks will be, instead of just guessing what the top tick will be which can be both wrong and misinformed.

Here's an extreme example of what this fixes: 
<img width="590" alt="image" src="https://github.com/FormidableLabs/victory-native-xl/assets/10779381/b090fe69-2082-4577-b9f5-4a2eda1b0fc6">
notice how now it doesn't cut off any of the tick values, even when they're absurdly long


#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?

In example app. Added example app option to play around with tick values directly. 

