### PR TITLE
Fix/300 bottom domain padding

### DIFF
--- a/.changeset/fifty-phones-search.md
+++ b/.changeset/fifty-phones-search.md
@@ -1,0 +1,5 @@
+---
+"victory-native": patch
+---
+
+fix domain padding bottom on bar charts

--- a/lib/src/cartesian/hooks/useBarGroupPaths.ts
+++ b/lib/src/cartesian/hooks/useBarGroupPaths.ts
@@ -41,17 +41,12 @@ export const useBarGroupPaths = (
   }, [barWidth, groupWidth, points.length]);
 
   const paths = React.useMemo(() => {
-    const hasNegativeYValues = points.some((pointSet) => {
-      return pointSet.some(({ yValue }) => yValue && yValue < 0);
-    });
     return points.map((pointSet, i) => {
       const p = Skia.Path.Make();
       const offset = -groupWidth / 2 + i * (barWidth + gapWidth);
       pointSet.forEach(({ x, y, yValue }) => {
         if (typeof y !== "number") return;
-        const barHeight = hasNegativeYValues
-          ? yScale(0) - y
-          : chartBounds.bottom - y;
+        const barHeight = yScale(0) - y;
         if (roundedCorners) {
           const nonUniformRoundedRect = createRoundedRectPath(
             x + offset,
@@ -68,15 +63,7 @@ export const useBarGroupPaths = (
       });
       return p;
     });
-  }, [
-    barWidth,
-    chartBounds.bottom,
-    gapWidth,
-    groupWidth,
-    points,
-    roundedCorners,
-    yScale,
-  ]);
+  }, [barWidth, gapWidth, groupWidth, points, roundedCorners, yScale]);
 
   return { barWidth, groupWidth, gapWidth, paths };
 };

--- a/lib/src/cartesian/hooks/useBarPath.ts
+++ b/lib/src/cartesian/hooks/useBarPath.ts
@@ -43,15 +43,11 @@ export const useBarPath = (
 
   const path = React.useMemo(() => {
     const path = Skia.Path.Make();
-    const hasNegativeYValues = points.some(
-      ({ yValue }) => yValue && yValue < 0,
-    );
 
     points.forEach(({ x, y, yValue }) => {
       if (typeof y !== "number") return;
-      const barHeight = hasNegativeYValues
-        ? yScale(0) - y
-        : chartBounds.bottom - y;
+
+      const barHeight = yScale(0) - y;
       if (roundedCorners) {
         const nonUniformRoundedRect = createRoundedRectPath(
           x,
@@ -68,7 +64,7 @@ export const useBarPath = (
     });
 
     return path;
-  }, [barWidth, chartBounds.bottom, points, roundedCorners, yScale]);
+  }, [barWidth, points, roundedCorners, yScale]);
 
   return { path, barWidth };
 };


### PR DESCRIPTION

### Description



Fixes #300 

For all bar charts, the barHeight is now calculated from the Y-axis origin (0) to the top/bottom of each bar, ensuring accurate rendering. This changes the previous impl. which had potential misrepresentation of bar heights.

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have run `yarn run check:code` and all checks pass
- [x] I have created a changeset for new features, patches, or major changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

![Simulator Screenshot - iPhone 15 Pro - 2024-06-19 at 08 21 05](https://github.com/FormidableLabs/victory-native-xl/assets/1131641/62277149-9f1f-41a9-89d7-9993ff5af02c)
<img width="150" alt="Screenshot 2024-06-19 at 8 23 00 AM" src="https://github.com/FormidableLabs/victory-native-xl/assets/1131641/08b2e547-b117-415a-a24b-0825e1ef5eba">
<img width="150" alt="Screenshot 2024-06-19 at 8 23 05 AM" src="https://github.com/FormidableLabs/victory-native-xl/assets/1131641/57717f42-07e7-42d7-91b2-7e494fc27617">
<img width="150" alt="Screenshot 2024-06-18 at 3 00 28 PM" src="https://github.com/FormidableLabs/victory-native-xl/assets/1131641/efcdbb8e-1808-4cd9-89b4-1f237a081f0a">

