### PR TITLE
Feature: Add circleSweepDegrees, startAngle props to PieChart

### DIFF
--- a/.changeset/quiet-tigers-promise.md
+++ b/.changeset/quiet-tigers-promise.md
@@ -1,0 +1,6 @@
+---
+"example": patch
+"victory-native": patch
+---
+
+Add circleSweepDegrees and startAngle props to PieChart

--- a/example/app/pie-and-donut-charts.tsx
+++ b/example/app/pie-and-donut-charts.tsx
@@ -290,6 +290,35 @@ const PieChartSimpleCustomLegend = () => {
   );
 };
 
+const HalfDonutChart = () => {
+  const [data] = useState(DATA(2));
+
+  return (
+    <PolarChart
+      data={data}
+      labelKey={"label"}
+      valueKey={"value"}
+      colorKey={"color"}
+    >
+      <Pie.Chart innerRadius={"50%"} circleSweepDegrees={180} startAngle={180}>
+        {() => {
+          return (
+            <>
+              <Pie.Slice />
+              <Pie.SliceAngularInset
+                angularInset={{
+                  angularStrokeWidth: 5,
+                  angularStrokeColor: "white",
+                }}
+              />
+            </>
+          );
+        }}
+      </Pie.Chart>
+    </PolarChart>
+  );
+};
+
 export default function PieAndDonutCharts(props: { segment: string }) {
   const description = descriptionForRoute(props.segment);
 
@@ -327,6 +356,10 @@ export default function PieAndDonutCharts(props: { segment: string }) {
         <View style={[styles.chartContainer]}>
           <Text style={styles.title}>Pie Chart with Custom Legend</Text>
           <PieChartSimpleCustomLegend />
+        </View>
+        <View style={[styles.chartContainer]}>
+          <Text style={styles.title}>Half Donut Chart</Text>
+          <HalfDonutChart />
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/lib/src/pie/PieChart.tsx
+++ b/lib/src/pie/PieChart.tsx
@@ -10,10 +10,17 @@ const CIRCLE_SWEEP_DEGREES = 360;
 type PieChartProps = {
   children?: (args: { slice: PieSliceData }) => React.ReactNode;
   innerRadius?: number | string;
+  circleSweepDegrees?: number;
+  startAngle?: number;
 };
 
 export const PieChart = (props: PieChartProps) => {
-  const { innerRadius = 0, children } = props;
+  const {
+    innerRadius = 0,
+    circleSweepDegrees = CIRCLE_SWEEP_DEGREES,
+    startAngle: _startAngle = 0,
+    children,
+  } = props;
   const {
     canvasSize,
     data: _data,
@@ -33,7 +40,7 @@ export const PieChart = (props: PieChartProps) => {
   const center = vec(width / 2, height / 2);
 
   const data = React.useMemo(() => {
-    let startAngle = 0; // Initialize the start angle for the first slice
+    let startAngle = _startAngle; // Initialize the start angle for the first slice
 
     const enhanced = _data.map((datum): PieSliceData => {
       const sliceValue = datum[valueKey] as number;
@@ -41,7 +48,7 @@ export const PieChart = (props: PieChartProps) => {
       const sliceColor = datum[colorKey] as Color;
 
       const initialStartAngle = startAngle; // grab the initial start angle
-      const sweepAngle = (sliceValue / totalCircleValue) * CIRCLE_SWEEP_DEGREES; // Calculate the sweep angle for the slice as a part of the entire pie
+      const sweepAngle = (sliceValue / totalCircleValue) * circleSweepDegrees; // Calculate the sweep angle for the slice as a part of the entire pie
       const endAngle = initialStartAngle + sweepAngle; // the sum of sweep + start
 
       startAngle += sweepAngle; // the next startAngle is the accumulation of each sweep

--- a/lib/src/pie/PieChart.tsx
+++ b/lib/src/pie/PieChart.tsx
@@ -77,6 +77,8 @@ export const PieChart = (props: PieChartProps) => {
     radius,
     center,
     innerRadius,
+    circleSweepDegrees,
+    _startAngle,
   ]);
 
   return data.map((slice, index) => {

--- a/website/docs/polar/pie/pie-charts.md
+++ b/website/docs/polar/pie/pie-charts.md
@@ -62,6 +62,14 @@ A `number` or `string` (as a percentage) which turns the `Pie` chart into a `Don
 The `innerRadius` prop must be a `number` or a `string` like `50%`.
 :::
 
+### `circleSweepDegrees`
+
+A `number` which defines how many degrees of the chart should be drawn. The default is `360` which will draw a full circle. If you want to draw a partial circle, you can set this prop to a value between `0` and `360`.
+
+### `startAngle`
+
+A `number` which defines the starting angle of the chart. Changing this prop will rotate the chart.
+
 ### `children`
 
 The `children` prop is a render function which maps through the data and whose sole argument is each individual `slice` of the pie, allowing you to customize each slice as needed. E.g. this slice will have all the data needed to render a `Pie.Slice />`.


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/victory-native-xl/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Currently PieChart could only be displayed in a full circle and does not allow any type of rotation. Adding circleSweepDegrees and startAngle as parameters to allow them to be changed. 

![Simulator Screenshot - iPhone 15 Pro - 2024-06-27 at 15 33 21](https://github.com/FormidableLabs/victory-native-xl/assets/32176865/5b765123-00e7-4996-91e2-d63c46f1a73f)

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Manual testing on iOS simulator. Added usage to example app. 
