### PR TITLE
Feature: Individual Bar Paths

### DIFF
--- a/.changeset/fast-chicken-run.md
+++ b/.changeset/fast-chicken-run.md
@@ -1,6 +1,6 @@
 ---
+"victory-native": minor
 "example": patch
-"victory-native": patch
 ---
 
 useBarPath returns path per bar

--- a/.changeset/fast-chicken-run.md
+++ b/.changeset/fast-chicken-run.md
@@ -1,0 +1,6 @@
+---
+"example": patch
+"victory-native": patch
+---
+
+useBarPath returns path per bar

--- a/example/app/negative-bar-charts.tsx
+++ b/example/app/negative-bar-charts.tsx
@@ -1,7 +1,15 @@
-import { LinearGradient, useFont, vec } from "@shopify/react-native-skia";
+import { LinearGradient, Path, useFont, vec } from "@shopify/react-native-skia";
 import React, { useState } from "react";
 import { SafeAreaView, ScrollView, StyleSheet, View } from "react-native";
-import { Bar, BarGroup, CartesianChart } from "victory-native";
+import {
+  Bar,
+  BarGroup,
+  CartesianChart,
+  useBarPath,
+  type ChartBounds,
+  type PointsArray,
+  type RoundedCorners,
+} from "victory-native";
 import { useDarkMode } from "react-native-dark";
 import inter from "../assets/inter-medium.ttf";
 import { appColors } from "./consts/colors";
@@ -22,6 +30,33 @@ const DATA = (length: number = 10) =>
     month: index + 1,
     listenCount: Math.floor(Math.random() * 801) - 300,
   }));
+
+function MyCustomBars({
+  points,
+  chartBounds,
+  innerPadding,
+  roundedCorners,
+}: {
+  points: PointsArray;
+  chartBounds: ChartBounds;
+  innerPadding?: number;
+  roundedCorners?: RoundedCorners;
+}) {
+  const { paths } = useBarPath(
+    points,
+    chartBounds,
+    innerPadding,
+    roundedCorners,
+  );
+  return paths.map((path, i) => (
+    <Path
+      key={i}
+      path={path}
+      style="fill"
+      color={(points[i]?.yValue ?? 0) >= 0 ? "#c084fc" : "#a5f3fc"}
+    />
+  ));
+}
 
 export default function NegativeBarChartsPage(props: { segment: string }) {
   const description = descriptionForRoute(props.segment);
@@ -122,6 +157,32 @@ export default function NegativeBarChartsPage(props: { segment: string }) {
                   />
                 </BarGroup.Bar>
               </BarGroup>
+            )}
+          </CartesianChart>
+        </View>
+        <View style={styles.chart}>
+          <CartesianChart
+            xKey="month"
+            padding={5}
+            yKeys={["listenCount"]}
+            domainPadding={{ left: 50, right: 50, top: 30, bottom: 20 }}
+            axisOptions={{
+              font,
+              lineColor: isDark ? "#71717a" : "#d4d4d8",
+              labelColor: isDark ? appColors.text.dark : appColors.text.light,
+            }}
+            data={data}
+          >
+            {({ points, chartBounds }) => (
+              <MyCustomBars
+                points={points.listenCount}
+                chartBounds={chartBounds}
+                innerPadding={innerPadding}
+                roundedCorners={{
+                  topLeft: roundedCorner,
+                  topRight: roundedCorner,
+                }}
+              />
             )}
           </CartesianChart>
         </View>

--- a/lib/src/cartesian/components/Bar.tsx
+++ b/lib/src/cartesian/components/Bar.tsx
@@ -27,7 +27,7 @@ export const Bar = ({
   barCount,
   ...ops
 }: PropsWithChildren<CartesianBarProps>) => {
-  const { path } = useBarPath(
+  const { paths } = useBarPath(
     points,
     chartBounds,
     innerPadding,
@@ -36,10 +36,13 @@ export const Bar = ({
     barCount,
   );
 
-  return React.createElement(animate ? AnimatedPath : Path, {
-    path,
-    style: "fill",
-    ...(Boolean(animate) && { animate }),
-    ...ops,
-  });
+  return paths.map((path, i) =>
+    React.createElement(animate ? AnimatedPath : Path, {
+      key: i,
+      path,
+      style: "fill",
+      ...(Boolean(animate) && { animate }),
+      ...ops,
+    }),
+  );
 };

--- a/lib/src/cartesian/hooks/useBarPath.ts
+++ b/lib/src/cartesian/hooks/useBarPath.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Skia } from "@shopify/react-native-skia";
+import { Skia, type SkPath } from "@shopify/react-native-skia";
 import {
   createRoundedRectPath,
   type RoundedCorners,
@@ -41,12 +41,11 @@ export const useBarPath = (
     barCount,
   ]);
 
-  const path = React.useMemo(() => {
-    const path = Skia.Path.Make();
-
+  const paths = React.useMemo(() => {
+    const paths: SkPath[] = [];
     points.forEach(({ x, y, yValue }) => {
+      const path = Skia.Path.Make();
       if (typeof y !== "number") return;
-
       const barHeight = yScale(0) - y;
       if (roundedCorners) {
         const nonUniformRoundedRect = createRoundedRectPath(
@@ -61,10 +60,10 @@ export const useBarPath = (
       } else {
         path.addRect(Skia.XYWHRect(x - barWidth / 2, y, barWidth, barHeight));
       }
+      paths.push(path);
     });
-
-    return path;
+    return paths;
   }, [barWidth, points, roundedCorners, yScale]);
 
-  return { path, barWidth };
+  return { paths, barWidth };
 };

--- a/website/docs/cartesian/bar/use-bar-path.md
+++ b/website/docs/cartesian/bar/use-bar-path.md
@@ -2,7 +2,7 @@
 
 The `useBarPath` hook takes a `PointsArray` input, a `ChartBounds` object, and an "inner padding" value, and returns a Skia `SkPath` path object that represents the path for that bar chart.
 
-## Exmaple
+## Example
 
 ```tsx
 import {
@@ -24,15 +24,19 @@ function MyCustomBars({
   innerPadding?: number;
 }) {
   // 👇 use the hook to generate a path object.
-  const { path } = useBarPath(points, chartBounds, innerPadding);
-  return <Path path={path} style="fill" color="red" />;
+  const { paths } = useBarPath(points, chartBounds, innerPadding);
+  return paths.map((path, i) => (
+    <Path key={i} path={path} style="fill" color="red" />
+  ));
 }
 
 export function MyChart() {
   return (
     <CartesianChart data={DATA} xKey="x" yKeys={["y"]}>
       {/* 👇 pass a PointsArray to our custom component */}
-      {({ points, chartBounds }) => <MyCustomBars points={points.y} chartBounds={chartBounds} />}
+      {({ points, chartBounds }) => (
+        <MyCustomBars points={points.y} chartBounds={chartBounds} />
+      )}
     </CartesianChart>
   );
 }
@@ -62,9 +66,9 @@ An optional `number` between 0 and 1 that represents what fraction of the horizo
 
 Returns an object with the following fields.
 
-### `path`
+### `paths`
 
-The `SkPath` path object to be used as the `path` argument of a Skia `<Path />` element.
+An array of `SkPath` path objects to be used as the `path` argument of a Skia `<Path />` element.
 
 ### `barWidth`
 


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/victory-native-xl/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Currently all bars of single bars can only be 1 colour. Changing the `path` variable to `paths` within `useBarPath` will allow for flexibility of customising each bar separately. This is an useful extension of the negative bars feature where positive and negative bars can have their own colours. An example has been added in the Negative Bar Charts page in the demo app. 

This change follows the same idea as BarChart groups where it returns a list of paths. 

Looks like this. Last chart is new. 
![diff-colours](https://github.com/FormidableLabs/victory-native-xl/assets/32176865/7ddc524b-6e30-4a86-974e-e8e05596bcc8)

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Manual testing on iOS simulator. Added usage to example app.
