### PR TITLE
Add curve type monotoneX

### DIFF
--- a/.changeset/famous-dingos-reflect.md
+++ b/.changeset/famous-dingos-reflect.md
@@ -1,0 +1,5 @@
+---
+"victory-native": patch
+---
+
+Add curve type `monotoneX` for lines

--- a/lib/src/cartesian/utils/curves.ts
+++ b/lib/src/cartesian/utils/curves.ts
@@ -4,6 +4,7 @@ import {
   curveCardinal,
   curveCatmullRom,
   curveLinear,
+  curveMonotoneX,
   curveNatural,
   curveStep,
 } from "d3-shape";
@@ -21,6 +22,7 @@ export const CURVES = {
   catmullRom: curveCatmullRom,
   catmullRom0: curveCatmullRom.alpha(0),
   catmullRom100: curveCatmullRom.alpha(1),
+  monotoneX: curveMonotoneX,
   step: curveStep,
 } as const;
 export type CurveType = keyof typeof CURVES;

--- a/website/docs/cartesian/area/use-area-path.md
+++ b/website/docs/cartesian/area/use-area-path.md
@@ -67,6 +67,7 @@ The `options` argument object has the following fields:
   - `catmullRom`
   - `catmullRom0`
   - `catmullRom100`
+  - `monotoneX`
   - `step`
 - `connectMissingData: boolean`: whether or not to interpolate missing data for this path (default is `false`). If set to `true`, the output will be a single, connected path (even if there are missing data values).
 


### PR DESCRIPTION
### Description

Added support for [curve type "monotoneX"](https://d3js.org/d3-shape/curve#curveMonotoneX) since I have a need for smooth lines that never goes above or below the values of the points. This curve type is smooth but not misleading.

#### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Tested locally by adding the option monotoneX to the Curve Type section of the Line Chart part of the example app - it works as intended -> makes the line smooth but not as extreme as the other options. I don't think it makes much sense of having this option in the example app since it makes the horizontal list too crowded.

### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have run `yarn run check:code` and all checks pass
- [x] I have created a changeset for new features, patches, or major changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
