### PR TITLE
Fix stacked bar rounded corners for non-uniform datasets

### DIFF
--- a/.changeset/pink-flowers-clap.md
+++ b/.changeset/pink-flowers-clap.md
@@ -3,4 +3,4 @@
 "victory-native": patch
 ---
 
-Fix stacked bar rounded corners for non-uniform datasets.
+Fix stacked bar rounded corners for non-uniform datasets and add support for positive and negative values in the same column.

--- a/.changeset/pink-flowers-clap.md
+++ b/.changeset/pink-flowers-clap.md
@@ -1,0 +1,6 @@
+---
+"example": patch
+"victory-native": patch
+---
+
+Fix stacked bar rounded corners for non-uniform datasets.

--- a/example/app/consts/routes.ts
+++ b/example/app/consts/routes.ts
@@ -36,7 +36,7 @@ export const ChartRoutes: {
   {
     title: "Negative Bar Charts",
     description:
-      "These charts demonstrate how negative values look with Bar and Bar Group charts.",
+      "These charts demonstrate how negative values look with Bar, Bar Group and Stacked Bar charts.",
     path: "/negative-bar-charts",
   },
   {

--- a/example/app/stacked-bar-charts-complex.tsx
+++ b/example/app/stacked-bar-charts-complex.tsx
@@ -219,6 +219,61 @@ const CustomChildrenChart = () => {
   );
 };
 
+const NonUniformDataSet = () => {
+  const font = useFont(inter, 12);
+  const isDark = useDarkMode();
+  const data = [
+    { month: 1, favouriteCount: 50, listenCount: 50, sales: 50 },
+    { month: 2, listenCount: 50, sales: 50 },
+    { month: 3, sales: 50 },
+    { month: 4, listenCount: 50, sales: 0 },
+    { month: 5, favouriteCount: 50, listenCount: 50, sales: 0 },
+  ];
+  const roundedCorner = 5;
+
+  return (
+    <View style={{ flex: 1 }}>
+      <CartesianChart
+        xKey="month"
+        padding={5}
+        yKeys={["favouriteCount", "listenCount", "sales"]}
+        domainPadding={{ left: 50, right: 50, top: 0 }}
+        domain={{ y: [0, 200] }}
+        axisOptions={{
+          font,
+          formatXLabel: (value) => {
+            const date = new Date(2023, value - 1);
+            return date.toLocaleString("default", { month: "short" });
+          },
+          lineColor: isDark ? "#71717a" : "#d4d4d8",
+          labelColor: isDark ? appColors.text.dark : appColors.text.light,
+        }}
+        data={data}
+      >
+        {({ points, chartBounds }) => {
+          return (
+            <StackedBar
+              barWidth={45}
+              innerPadding={0.33}
+              chartBounds={chartBounds}
+              points={[points.favouriteCount, points.listenCount, points.sales]}
+              colors={["blue", "red", "green"]}
+              barOptions={({ isBottom, isTop }) => ({
+                roundedCorners: {
+                  topLeft: isTop ? roundedCorner : 0,
+                  topRight: isTop ? roundedCorner : 0,
+                  bottomRight: isBottom ? roundedCorner : 0,
+                  bottomLeft: isBottom ? roundedCorner : 0,
+                },
+              })}
+            />
+          );
+        }}
+      </CartesianChart>
+    </View>
+  );
+};
+
 export default function StackedBarChartsComplexPage() {
   return (
     <>
@@ -237,6 +292,13 @@ export default function StackedBarChartsComplexPage() {
           <View style={styles.chartContainer}>
             <Text style={styles.title}>Stacked chart with custom children</Text>
             <CustomChildrenChart />
+          </View>
+          <View style={styles.chartContainer}>
+            <Text style={styles.title}>
+              Rounded corners where some data points are missing or values are
+              zero
+            </Text>
+            <NonUniformDataSet />
           </View>
         </ScrollView>
       </SafeAreaView>

--- a/example/components/Checkbox.tsx
+++ b/example/components/Checkbox.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import { Pressable, StyleSheet, View } from "react-native";
+import Ionicons from "@expo/vector-icons/Ionicons";
+import { Text } from "./Text";
+
+type Props = {
+  label?: string;
+  checked: boolean;
+  onChange(): void;
+};
+
+export const Checkbox = ({ label, checked, onChange }: Props) => {
+  return (
+    <View style={{ flexDirection: "row", gap: 10, alignItems: "center" }}>
+      <Pressable
+        style={[styles.checkboxBase, checked && styles.checkboxChecked]}
+        onPress={onChange}
+      >
+        {checked && <Ionicons name="checkmark" size={18} color="white" />}
+      </Pressable>
+      {label ? <Text>{label}</Text> : null}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  checkboxBase: {
+    width: 24,
+    height: 24,
+    justifyContent: "center",
+    alignItems: "center",
+    borderRadius: 4,
+    borderWidth: 2,
+    borderColor: "coral",
+    backgroundColor: "transparent",
+  },
+  checkboxChecked: {
+    backgroundColor: "coral",
+  },
+});

--- a/lib/src/cartesian/hooks/useStackedBarPaths.ts
+++ b/lib/src/cartesian/hooks/useStackedBarPaths.ts
@@ -84,12 +84,12 @@ export const useStackedBarPaths = ({
 
   const paths = React.useMemo(() => {
     const bars: StackedBarPath[] = [];
+    const xToBottomTopIndexMap = getXToPointIndexMap(points);
 
     points.forEach((pointsArray, i) => {
-      const isTop = i === points.length - 1; // the top "row" of the stack of bars
-      const isBottom = i === 0; // the bottom "row" of the stack bars
-
       pointsArray.forEach((point, j) => {
+        const isBottom = xToBottomTopIndexMap.get(point.x)?.[0] === i;
+        const isTop = xToBottomTopIndexMap.get(point.x)?.[1] === i;
         const { yValue, x, y } = point;
         if (typeof y !== "number") return;
 
@@ -144,4 +144,27 @@ export const useStackedBarPaths = ({
   }, [barOptions, barWidth, barYPositionOffsetTracker, colors, points, yScale]);
 
   return paths;
+};
+
+/**
+ * Returns a map of x values to a two value array where the first number is the index of
+ * the bottom bar and the second is the index of the top bar.
+ */
+const getXToPointIndexMap = (
+  points: PointsArray[],
+): Map<number, [number, number]> => {
+  const xToIndexMap = new Map<number, [number, number]>();
+  points.forEach((pointsArray, i) => {
+    pointsArray.forEach(({ x, y, yValue }) => {
+      if (y !== null && y !== undefined && yValue !== 0) {
+        const current = xToIndexMap.get(x);
+        if (!current) {
+          xToIndexMap.set(x, [i, i]);
+        } else {
+          current[1] = i;
+        }
+      }
+    });
+  });
+  return xToIndexMap;
 };

--- a/lib/src/cartesian/hooks/useStackedBarPaths.ts
+++ b/lib/src/cartesian/hooks/useStackedBarPaths.ts
@@ -46,6 +46,7 @@ type Props = {
     rowIndex: number;
   }) => CustomizablePathProps & { roundedCorners?: RoundedCorners };
 };
+
 export const useStackedBarPaths = ({
   points,
   chartBounds,
@@ -68,18 +69,10 @@ export const useStackedBarPaths = ({
   // so that we know where to start drawing the next bar for each x value
   const barYPositionOffsetTracker = points.reduce(
     (acc, points) => {
-      points.map((point) => {
-        const xValue = point.xValue;
-        if (acc[xValue]) {
-          acc[xValue] += 0 as number;
-        } else {
-          acc[xValue] = 0 as number;
-        }
-      });
-
+      points.map((point) => (acc[point.xValue] = [0, 0]));
       return acc;
     },
-    {} as Record<InputFieldType, number>,
+    {} as Record<InputFieldType, number[]>,
   );
 
   const paths = React.useMemo(() => {
@@ -92,25 +85,28 @@ export const useStackedBarPaths = ({
         const isTop = xToBottomTopIndexMap.get(point.x)?.[1] === i;
         const { yValue, x, y } = point;
         if (typeof y !== "number") return;
+        const isPositive = (yValue ?? 0) > 0;
 
         // call for any additional bar options per bar
         const options = barOptions({
           columnIndex: i,
           rowIndex: j,
-          isBottom,
-          isTop,
+          isBottom: isPositive ? isBottom : isTop,
+          isTop: isPositive ? isTop : isBottom,
         });
         const { roundedCorners, color, ...ops } = options;
 
         const path = Skia.Path.Make();
-
         const barHeight = yScale(0) - y;
-        const offset = barYPositionOffsetTracker?.[point.xValue!] ?? 0;
+
+        const offset = isPositive
+          ? barYPositionOffsetTracker?.[point.xValue!]?.[0]
+          : barYPositionOffsetTracker?.[point.xValue!]?.[1];
 
         if (roundedCorners) {
           const nonUniformRoundedRect = createRoundedRectPath(
             x,
-            y - offset,
+            y - (offset ?? 0),
             barWidth,
             barHeight,
             roundedCorners,
@@ -121,14 +117,20 @@ export const useStackedBarPaths = ({
           path.addRect(
             Skia.XYWHRect(
               point.x - barWidth / 2,
-              y - offset,
+              y - (offset ?? 0),
               barWidth,
               barHeight,
             ),
           );
         }
 
-        barYPositionOffsetTracker[point.xValue!] = barHeight + offset; // accumulate the heights as we loop
+        if (notNullAndUndefined(offset)) {
+          if (isPositive) {
+            barYPositionOffsetTracker[point.xValue!]![0] = barHeight + offset; // accumulate the positive heights as we loop
+          } else {
+            barYPositionOffsetTracker[point.xValue!]![1] = barHeight + offset; // accumulate the negative heights as we loop
+          }
+        }
 
         const bar = {
           path,
@@ -156,15 +158,22 @@ const getXToPointIndexMap = (
   const xToIndexMap = new Map<number, [number, number]>();
   points.forEach((pointsArray, i) => {
     pointsArray.forEach(({ x, y, yValue }) => {
-      if (y !== null && y !== undefined && yValue !== 0) {
+      if (
+        notNullAndUndefined(y) &&
+        notNullAndUndefined(yValue) &&
+        yValue !== 0
+      ) {
         const current = xToIndexMap.get(x);
         if (!current) {
           xToIndexMap.set(x, [i, i]);
         } else {
-          current[1] = i;
+          yValue > 0 ? (current[1] = i) : (current[0] = i);
         }
       }
     });
   });
   return xToIndexMap;
 };
+
+const notNullAndUndefined = <T>(value: T | null | undefined): value is T =>
+  value !== null && value !== undefined;


### PR DESCRIPTION
This fix handles rounded corners when datasets have y-values that are missing or zero.

### Description

I noticed that if a dataset does not have all y-values or 0-values the rounded corners doesn't get applied correctly:

<img width="476" alt="image" src="https://github.com/user-attachments/assets/e423bf6e-7017-485c-98f6-9dcc88bd59f7">

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

I added an new "complex stacked bar" example with a dataset with the aformentioned non-uniformity (see screenshot above). After this fix it now looks like this:

<img width="487" alt="image" src="https://github.com/user-attachments/assets/3c195c19-c138-4cfb-8a41-af960693fc83">
