### PR TITLE
feat: add pie size prop

### DIFF
--- a/.changeset/hip-worms-cover.md
+++ b/.changeset/hip-worms-cover.md
@@ -1,0 +1,5 @@
+---
+"victory-native": patch
+---
+
+Add pie size prop

--- a/lib/src/pie/PieChart.tsx
+++ b/lib/src/pie/PieChart.tsx
@@ -12,6 +12,7 @@ type PieChartProps = {
   innerRadius?: number | string;
   circleSweepDegrees?: number;
   startAngle?: number;
+  size?: number;
 };
 
 export const PieChart = (props: PieChartProps) => {
@@ -20,6 +21,7 @@ export const PieChart = (props: PieChartProps) => {
     circleSweepDegrees = CIRCLE_SWEEP_DEGREES,
     startAngle: _startAngle = 0,
     children,
+    size,
   } = props;
   const {
     canvasSize,
@@ -35,12 +37,13 @@ export const PieChart = (props: PieChartProps) => {
     0,
   );
 
-  const { width, height } = canvasSize; // Get the dynamic canvas size
+  const width = size ?? canvasSize.width; // Get the dynamic canvas size
+  const height = size ?? canvasSize.height; // Get the dynamic canvas size
 
   // The size of the chart will need to be adjusted if the labels are positioned outside the chart.
   // ie we need to decrease the Pie Charts radius to account for the labels so the labels don't get cut off.
   const radius = Math.min(width, height) / 2; // Calculate the radius based on canvas size
-  const center = vec(width / 2, height / 2);
+  const center = vec(canvasSize.width / 2, canvasSize.height / 2);
 
   const data = React.useMemo(() => {
     let startAngle = _startAngle; // Initialize the start angle for the first slice

--- a/website/docs/polar/pie/pie-charts.md
+++ b/website/docs/polar/pie/pie-charts.md
@@ -70,6 +70,10 @@ A `number` which defines how many degrees of the chart should be drawn. The defa
 
 A `number` which defines the starting angle of the chart. Changing this prop will rotate the chart.
 
+### `size`
+
+A `number` which defines the size of the chart. This defaults to the canvas' width and height. This can be overriden with this prop (in case you want to position labels outside the chart, for example)
+
 ### `children`
 
 The `children` prop is a render function which maps through the data and whose sole argument is each individual `slice` of the pie, allowing you to customize each slice as needed. E.g. this slice will have all the data needed to render a `Pie.Slice />`.


### PR DESCRIPTION
### Description

Adds pie size prop so that it is customizable and not just the width/height of the canvas itself. This is partially useful for being able to position the labels beyond the pie itself.

Fixes #390 

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have run `yarn run check:code` and all checks pass
- [x] I have created a changeset for new features, patches, or major changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
