### PR TITLE
Make frame line width configurable per side

### DIFF
--- a/.changeset/proud-lions-protect.md
+++ b/.changeset/proud-lions-protect.md
@@ -1,0 +1,5 @@
+---
+"victory-native": minor
+---
+
+Updates the lineWidth prop for frame to allow for configuring the width per side.

--- a/lib/src/cartesian/components/Frame.tsx
+++ b/lib/src/cartesian/components/Frame.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { StyleSheet } from "react-native";
-import { Path, Skia } from "@shopify/react-native-skia";
+import { Group, Line, Path, Skia, vec } from "@shopify/react-native-skia";
 import type { FrameProps } from "../../types";
 
 export const Frame = ({
@@ -16,30 +16,77 @@ export const Frame = ({
   const boundingFrame = React.useMemo(() => {
     const framePath = Skia.Path.Make();
 
-    framePath.addRect(
-      Skia.XYWHRect(
-        xScale(x1),
-        yScale(y1),
-        xScale(x2) - xScale(x1),
-        yScale(y2) - yScale(y1),
-      ),
-    );
-    return framePath;
-  }, [x1, x2, xScale, y1, y2, yScale]);
+    if (typeof lineWidth === "number") {
+      framePath.addRect(
+        Skia.XYWHRect(
+          xScale(x1),
+          yScale(y1),
+          xScale(x2) - xScale(x1),
+          yScale(y2) - yScale(y1),
+        ),
+      );
 
-  if (lineWidth <= 0) {
+      return <Path path={framePath} strokeWidth={lineWidth} />;
+    } else {
+      const lines = [];
+      const _lineWidth = {
+        top: StyleSheet.hairlineWidth,
+        right: StyleSheet.hairlineWidth,
+        bottom: StyleSheet.hairlineWidth,
+        left: StyleSheet.hairlineWidth,
+        ...lineWidth,
+      };
+
+      if (_lineWidth.top > 0) {
+        lines.push(
+          <Line
+            p1={vec(xScale(x1), yScale(y1))}
+            p2={vec(xScale(x2), yScale(y1))}
+            strokeWidth={lineWidth.top}
+          />,
+        );
+      }
+      if (_lineWidth.right > 0) {
+        lines.push(
+          <Line
+            p1={vec(xScale(x2), yScale(y1))}
+            p2={vec(xScale(x2), yScale(y2))}
+            strokeWidth={lineWidth.right}
+          />,
+        );
+      }
+      if (_lineWidth.bottom > 0) {
+        lines.push(
+          <Line
+            p1={vec(xScale(x2), yScale(y2))}
+            p2={vec(xScale(x1), yScale(y2))}
+            strokeWidth={lineWidth.bottom}
+          />,
+        );
+      }
+      if (_lineWidth.left > 0) {
+        lines.push(
+          <Line
+            p1={vec(xScale(x1), yScale(y2))}
+            p2={vec(xScale(x1), yScale(y1))}
+            strokeWidth={lineWidth.left}
+          />,
+        );
+      }
+      return lines;
+    }
+  }, [x1, x2, xScale, y1, y2, yScale, lineWidth]);
+
+  if (typeof lineWidth === "number" && lineWidth <= 0) {
     return null;
   }
 
+  // return boundingFrame;
   return (
-    <Path
-      path={boundingFrame}
-      strokeWidth={lineWidth}
-      style="stroke"
-      color={lineColor}
-    >
-      {linePathEffect ? linePathEffect : null}
-    </Path>
+    <Group color={lineColor} style="stroke">
+      {linePathEffect}
+      {boundingFrame}
+    </Group>
   );
 };
 

--- a/lib/src/cartesian/components/Frame.tsx
+++ b/lib/src/cartesian/components/Frame.tsx
@@ -26,7 +26,7 @@ export const Frame = ({
         ),
       );
 
-      return <Path path={framePath} strokeWidth={lineWidth} />;
+      return <Path key="full-frame" path={framePath} strokeWidth={lineWidth} />;
     } else {
       const lines = [];
       const _lineWidth = {
@@ -40,6 +40,7 @@ export const Frame = ({
       if (_lineWidth.top > 0) {
         lines.push(
           <Line
+            key="frame-top"
             p1={vec(xScale(x1), yScale(y1))}
             p2={vec(xScale(x2), yScale(y1))}
             strokeWidth={lineWidth.top}
@@ -49,6 +50,7 @@ export const Frame = ({
       if (_lineWidth.right > 0) {
         lines.push(
           <Line
+            key="frame-right"
             p1={vec(xScale(x2), yScale(y1))}
             p2={vec(xScale(x2), yScale(y2))}
             strokeWidth={lineWidth.right}
@@ -58,6 +60,7 @@ export const Frame = ({
       if (_lineWidth.bottom > 0) {
         lines.push(
           <Line
+            key="frame-bottom"
             p1={vec(xScale(x2), yScale(y2))}
             p2={vec(xScale(x1), yScale(y2))}
             strokeWidth={lineWidth.bottom}
@@ -67,6 +70,7 @@ export const Frame = ({
       if (_lineWidth.left > 0) {
         lines.push(
           <Line
+            key="frame-left"
             p1={vec(xScale(x1), yScale(y2))}
             p2={vec(xScale(x1), yScale(y1))}
             strokeWidth={lineWidth.left}

--- a/lib/src/cartesian/components/Frame.tsx
+++ b/lib/src/cartesian/components/Frame.tsx
@@ -85,7 +85,6 @@ export const Frame = ({
     return null;
   }
 
-  // return boundingFrame;
   return (
     <Group color={lineColor} style="stroke">
       {linePathEffect}

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -239,7 +239,7 @@ export type YAxisProps<
 };
 
 export type FrameInputProps = {
-  lineWidth?: number;
+  lineWidth?: SidedNumber;
   lineColor?: Color;
   linePathEffect?: DashPathEffectComponent;
 };

--- a/website/docs/cartesian/cartesian-chart.md
+++ b/website/docs/cartesian/cartesian-chart.md
@@ -161,7 +161,7 @@ The `frame` is an optional prop allows you to configure the frame of the chart. 
 |       Property       | Type                             | Description                                                                                                                                                                 |
 | :------------------: | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 |   **`lineColor`**    | <pre>Color (RN Skia Color)</pre> | Defines the color of the frame. It will default to `hsla(0, 0%, 0%, 0.25)` if none is provided.                                                                             |
-|   **`lineWidth`**    | <pre>number &#124; {top: number; bottom: number; left: number; right: number}</pre> | Defines the width of the frame. It will default to `Stylesheet.hairlineWidth` if none is provided. A value of `0` will disable the line rendering.                          |
+|   **`lineWidth`**    | <pre>number &#124; \{top: number; bottom: number; left: number; right: number\}</pre> | Defines the width of the frame. It will default to `Stylesheet.hairlineWidth` if none is provided. A value of `0` will disable the line rendering.                          |
 | **`linePathEffect`** | <pre>`DashPathEffect`</pre>      | Currently accepts the `<DashPathEffect />` from `react-native-skia` so one can add dashes to the frame. In the future this prop may accept other line path effects as well. |
 
 ### `chartPressState`

--- a/website/docs/cartesian/cartesian-chart.md
+++ b/website/docs/cartesian/cartesian-chart.md
@@ -161,7 +161,7 @@ The `frame` is an optional prop allows you to configure the frame of the chart. 
 |       Property       | Type                             | Description                                                                                                                                                                 |
 | :------------------: | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 |   **`lineColor`**    | <pre>Color (RN Skia Color)</pre> | Defines the color of the frame. It will default to `hsla(0, 0%, 0%, 0.25)` if none is provided.                                                                             |
-|   **`lineWidth`**    | <pre>number</pre>                | Defines the width of the frame. It will default to `Stylesheet.hairlineWidth` if none is provided. A value of `0` will disable the line rendering.                          |
+|   **`lineWidth`**    | <pre>number \| {top: number; bottom: number; left: number; right: number}</pre> | Defines the width of the frame. It will default to `Stylesheet.hairlineWidth` if none is provided. A value of `0` will disable the line rendering.                          |
 | **`linePathEffect`** | <pre>`DashPathEffect`</pre>      | Currently accepts the `<DashPathEffect />` from `react-native-skia` so one can add dashes to the frame. In the future this prop may accept other line path effects as well. |
 
 ### `chartPressState`

--- a/website/docs/cartesian/cartesian-chart.md
+++ b/website/docs/cartesian/cartesian-chart.md
@@ -161,7 +161,7 @@ The `frame` is an optional prop allows you to configure the frame of the chart. 
 |       Property       | Type                             | Description                                                                                                                                                                 |
 | :------------------: | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 |   **`lineColor`**    | <pre>Color (RN Skia Color)</pre> | Defines the color of the frame. It will default to `hsla(0, 0%, 0%, 0.25)` if none is provided.                                                                             |
-|   **`lineWidth`**    | <pre>number \| {top: number; bottom: number; left: number; right: number}</pre> | Defines the width of the frame. It will default to `Stylesheet.hairlineWidth` if none is provided. A value of `0` will disable the line rendering.                          |
+|   **`lineWidth`**    | <pre>number &#124; {top: number; bottom: number; left: number; right: number}</pre> | Defines the width of the frame. It will default to `Stylesheet.hairlineWidth` if none is provided. A value of `0` will disable the line rendering.                          |
 | **`linePathEffect`** | <pre>`DashPathEffect`</pre>      | Currently accepts the `<DashPathEffect />` from `react-native-skia` so one can add dashes to the frame. In the future this prop may accept other line path effects as well. |
 
 ### `chartPressState`


### PR DESCRIPTION
Updates the `lineWidth` prop for `frame` to allow for configuring the width per side.

<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/victory-native-xl/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #394

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have run `yarn run check:code` and all checks pass
- [x] I have created a changeset for new features, patches, or major changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
