### PR TITLE
Fix issue determining StackedBar count

### DIFF
--- a/.changeset/dull-tomatoes-mate.md
+++ b/.changeset/dull-tomatoes-mate.md
@@ -1,0 +1,5 @@
+---
+"victory-native": patch
+---
+
+Fix determining stacked bar count from points structure

--- a/lib/src/cartesian/hooks/useBarWidth.ts
+++ b/lib/src/cartesian/hooks/useBarWidth.ts
@@ -17,6 +17,13 @@ export const useBarWidth = ({
   barCount,
   points,
 }: Props) => {
+  // stacked bars pass a PointsArray[] type which requires us to get
+  // the points length from the length of the first entry.
+  const pointsLength =
+    points.length > 0 && Array.isArray(points[0])
+      ? points[0].length
+      : points.length;
+
   const barWidth = React.useMemo(() => {
     if (customBarWidth) return customBarWidth;
     const domainWidth = chartBounds.right - chartBounds.left;
@@ -25,10 +32,10 @@ export const useBarWidth = ({
 
     const denominator = barCount
       ? barCount
-      : points.length - 1 <= 0
+      : pointsLength - 1 <= 0
         ? // don't divide by 0 if there's only one data point
-          points.length
-        : points.length - 1;
+          pointsLength
+        : pointsLength - 1;
 
     const barWidth = numerator / denominator;
 
@@ -38,7 +45,7 @@ export const useBarWidth = ({
     chartBounds.left,
     chartBounds.right,
     innerPadding,
-    points.length,
+    pointsLength,
     barCount,
   ]);
   return barWidth;


### PR DESCRIPTION
Fixes issue where we weren't properly determining the number of statcked backs from the points data structure.

<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/victory-native-xl/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #401

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have run `yarn run check:code` and all checks pass
- [x] I have created a changeset for new features, patches, or major changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
