### PR TITLE
Add `matchedIndex` to chart press state

### DIFF
--- a/.changeset/neat-mice-sneeze.md
+++ b/.changeset/neat-mice-sneeze.md
@@ -1,0 +1,5 @@
+---
+"victory-native": minor
+---
+
+Add `matchedIndex` to chart press state

--- a/example/app/bar-charts-custom-bars.tsx
+++ b/example/app/bar-charts-custom-bars.tsx
@@ -26,7 +26,7 @@ export default function BarChartCustomBarsPage() {
   });
 
   let activeXItem = useDerivedValue(() => {
-    return data.findIndex((value) => value.month === state.x.value.value);
+    return state.matchedIndex.value;
   }).value;
   if (activeXItem < 0) {
     activeXItem = 2;

--- a/example/app/stacked-bar-charts-complex.tsx
+++ b/example/app/stacked-bar-charts-complex.tsx
@@ -26,7 +26,7 @@ const IndividualTouchableBarChart = () => {
     y: { favouriteCount: 0, listenCount: 0, sales: 0 },
   });
 
-  const pressedXY = { x: state.x.value.value - 1, y: state.yIndex.value };
+  const pressedXY = { x: state.matchedIndex.value, y: state.yIndex.value };
   return (
     <View style={{ flex: 1 }}>
       <CartesianChart

--- a/lib/src/cartesian/CartesianChart.tsx
+++ b/lib/src/cartesian/CartesianChart.tsx
@@ -227,6 +227,7 @@ export function CartesianChart<
 
     if (v) {
       try {
+        v.matchedIndex.value = idx;
         v.x.value.value = tData.value.ix[idx]!;
         v.x.position.value = asNumber(tData.value.ox[idx]);
         for (const yk in v.y) {

--- a/lib/src/cartesian/hooks/useChartPressState.ts
+++ b/lib/src/cartesian/hooks/useChartPressState.ts
@@ -15,6 +15,7 @@ export const useChartPressState = <Init extends ChartPressStateInit>(
   const state = React.useMemo(() => {
     return {
       isActive: makeMutable(false),
+      matchedIndex: makeMutable(-1),
       x: { value: makeMutable(initialValues.x), position: makeMutable(0) },
       y: Object.entries(initialValues.y).reduce(
         (acc, [key, initVal]) => {
@@ -42,7 +43,11 @@ export const useChartPressState = <Init extends ChartPressStateInit>(
 type ChartPressStateInit = { x: InputFieldType; y: Record<string, number> };
 export type ChartPressState<Init extends ChartPressStateInit> = {
   isActive: SharedValue<boolean>;
-  x: { value: SharedValue<Init["x"]>; position: SharedValue<number> };
+  matchedIndex: SharedValue<number>;
+  x: {
+    value: SharedValue<Init["x"]>;
+    position: SharedValue<number>;
+  };
   y: Record<
     keyof Init["y"],
     { value: SharedValue<number>; position: SharedValue<number> }


### PR DESCRIPTION
Adds new field, `matchedIndex` to the chart press state to allow easily determining which point is being pressed.

<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/victory-native-xl/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #326

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have run `yarn run check:code` and all checks pass
- [x] I have created a changeset for new features, patches, or major changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
