### PR TITLE
Fix Reanimated warning with accessing shared value on render

### DIFF
--- a/.changeset/pink-llamas-punch.md
+++ b/.changeset/pink-llamas-punch.md
@@ -1,0 +1,5 @@
+---
+"victory-native": patch
+---
+
+Fixes Reanimated warning

--- a/lib/src/cartesian/contexts/CartesianTransformContext.tsx
+++ b/lib/src/cartesian/contexts/CartesianTransformContext.tsx
@@ -2,6 +2,7 @@ import React, {
   createContext,
   type PropsWithChildren,
   useContext,
+  useEffect,
   useState,
 } from "react";
 import { runOnJS, useAnimatedReaction } from "react-native-reanimated";
@@ -38,7 +39,13 @@ export const CartesianTransformProvider = ({
     k: number;
     tx: number;
     ty: number;
-  }>(getTransformComponents(transformState));
+  }>(getTransformComponents(undefined));
+
+  useEffect(() => {
+    if (transformState) {
+      setTransform(getTransformComponents(transformState));
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useAnimatedReaction(
     () => {


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/victory-native-xl/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have run `yarn run check:code` and all checks pass
- [x] I have created a changeset for new features, patches, or major changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
