### PR TITLE
Add `its-fine` for polar charts

### DIFF
--- a/.changeset/empty-islands-hang.md
+++ b/.changeset/empty-islands-hang.md
@@ -1,0 +1,5 @@
+---
+"victory-native": patch
+---
+
+add package 'its-fine' for polar chart shared contexts

--- a/lib/package.json
+++ b/lib/package.json
@@ -36,14 +36,15 @@
     "d3-scale": "^4.0.2",
     "d3-shape": "^3.2.0",
     "d3-zoom": "^3.0.0",
+    "its-fine": "^1.2.5",
     "react-fast-compare": "^3.2.2"
   },
   "peerDependencies": {
+    "@shopify/react-native-skia": ">=1.2.3",
     "react": "*",
     "react-native": "*",
-    "@shopify/react-native-skia": ">=1.2.3",
-    "react-native-reanimated": ">=3.0.0",
-    "react-native-gesture-handler": ">=2.0.0"
+    "react-native-gesture-handler": ">=2.0.0",
+    "react-native-reanimated": ">=3.0.0"
   },
   "devDependencies": {
     "@types/d3-scale": "^4.0.3",

--- a/lib/src/polar/PolarChart.tsx
+++ b/lib/src/polar/PolarChart.tsx
@@ -8,10 +8,8 @@ import {
   type StyleProp,
 } from "react-native";
 import { Gesture, GestureHandlerRootView } from "react-native-gesture-handler";
-import {
-  PolarChartProvider,
-  usePolarChartContext,
-} from "./contexts/PolarChartContext";
+import { type ContextBridge, FiberProvider, useContextBridge } from "its-fine";
+import { PolarChartProvider } from "./contexts/PolarChartContext";
 import type {
   ColorFields,
   InputFields,
@@ -47,8 +45,7 @@ const PolarChartBase = (
     transformState,
   } = props;
   const { width, height } = canvasSize;
-
-  const ctx = usePolarChartContext();
+  const Bridge: ContextBridge = useContextBridge();
 
   let composed = Gesture.Race();
   if (transformState) {
@@ -70,12 +67,9 @@ const PolarChartBase = (
             canvasStyle,
           ])}
         >
-          {/* https://shopify.github.io/react-native-skia/docs/canvas/contexts/
-            we have to re-inject our context to make it available in the skia renderer
-         */}
-          <PolarChartProvider {...ctx} canvasSize={canvasSize}>
+          <Bridge>
             <Group matrix={transformState?.matrix}>{children}</Group>
-          </PolarChartProvider>
+          </Bridge>
         </Canvas>
         <GestureHandler
           gesture={composed}
@@ -126,20 +120,22 @@ export const PolarChart = <
   );
 
   return (
-    <PolarChartProvider
-      data={data}
-      labelKey={labelKey.toString()}
-      colorKey={colorKey.toString()}
-      valueKey={valueKey.toString()}
-      canvasSize={canvasSize}
-    >
-      <PolarChartBase
-        {...props}
-        onLayout={onLayout}
-        hasMeasuredLayoutSize={hasMeasuredLayoutSize}
+    <FiberProvider>
+      <PolarChartProvider
+        data={data}
+        labelKey={labelKey.toString()}
+        colorKey={colorKey.toString()}
+        valueKey={valueKey.toString()}
         canvasSize={canvasSize}
-      />
-    </PolarChartProvider>
+      >
+        <PolarChartBase
+          {...props}
+          onLayout={onLayout}
+          hasMeasuredLayoutSize={hasMeasuredLayoutSize}
+          canvasSize={canvasSize}
+        />
+      </PolarChartProvider>
+    </FiberProvider>
   );
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2738,6 +2738,21 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.12.tgz#12bb1e2be27293c1406acb6af1c3f3a1481d98c6"
   integrity sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==
 
+"@types/react-reconciler@^0.28.0":
+  version "0.28.8"
+  resolved "https://registry.yarnpkg.com/@types/react-reconciler/-/react-reconciler-0.28.8.tgz#e51710572bcccf214306833c2438575d310b3e98"
+  integrity sha512-SN9c4kxXZonFhbX4hJrZy37yw9e7EIxcpHCxQv5JUS18wDE5ovkQKlqQEkufdJCCMfuI9BnjUJvhYeJ9x5Ra7g==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*":
+  version "18.3.13"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.13.tgz#84c9690d9a271f548659760754ea8745701bfd82"
+  integrity sha512-ii/gswMmOievxAJed4PAHT949bpYjPKXvXo1v6cRB/kqc2ZR4n+SgyCyvyc5Fec5ez8VnUumI1Vk7j6fRyRogg==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
+
 "@types/react@~18.2.14":
   version "18.2.79"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.79.tgz#c40efb4f255711f554d47b449f796d1c7756d865"
@@ -5982,6 +5997,13 @@ iterator.prototype@^1.1.2:
     has-symbols "^1.0.3"
     reflect.getprototypeof "^1.0.4"
     set-function-name "^2.0.1"
+
+its-fine@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/its-fine/-/its-fine-1.2.5.tgz#5466c287f86a0a73e772c8d8d515626c97195dc9"
+  integrity sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==
+  dependencies:
+    "@types/react-reconciler" "^0.28.0"
 
 jackspeak@^3.1.2:
   version "3.4.3"


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/victory-native-xl/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

Adds `its-fine` for polar charts since the current implementation of sharing contexts between renderers no longer seems like it's working.

This isn't the most ideal solution, but it will at least fix the errors that are thrown/logged currently for existing users. See #433 for more details

Fixes #433 

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have run `yarn run check:code` and all checks pass
- [ ] I have created a changeset for new features, patches, or major changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
