### PR TITLE
Fix/bar path adjustment

### DIFF
--- a/.changeset/wild-mayflies-tickle.md
+++ b/.changeset/wild-mayflies-tickle.md
@@ -1,0 +1,5 @@
+---
+"victory-native": patch
+---
+
+Fix bar group positioning

--- a/lib/src/cartesian/hooks/useBarPath.ts
+++ b/lib/src/cartesian/hooks/useBarPath.ts
@@ -35,7 +35,7 @@ export const useBarPath = (
 
       if (roundedCorners) {
         const nonUniformRoundedRect = createRoundedRectPath(
-          x,
+          x - barWidth / 2,
           y,
           barWidth,
           barHeight,

--- a/lib/src/cartesian/hooks/useStackedBarPaths.ts
+++ b/lib/src/cartesian/hooks/useStackedBarPaths.ts
@@ -105,7 +105,7 @@ export const useStackedBarPaths = ({
 
         if (roundedCorners) {
           const nonUniformRoundedRect = createRoundedRectPath(
-            x,
+            x - barWidth / 2,
             y - (offset ?? 0),
             barWidth,
             barHeight,

--- a/lib/src/utils/createRoundedRectPath.ts
+++ b/lib/src/utils/createRoundedRectPath.ts
@@ -41,7 +41,7 @@ export const createRoundedRectPath = (
 
   const nonUniformRoundedRect = {
     rect: {
-      x: x - barWidth / 2,
+      x: x,
       y: y,
       width: barWidth,
       height: barHeight,


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/victory-native-xl/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

Fixes an issue where we were double adjusting a x value for bar group paths

Fixes #475  

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Before:
You can see it's shifted
<img width="300" alt="Screenshot 2025-01-16 at 2 38 25 PM" src="https://github.com/user-attachments/assets/2abec6e1-4300-40c8-9c66-e4a340528775" />


After:
It's now centered
<img width="300" alt="Screenshot 2025-01-16 at 1 51 17 PM" src="https://github.com/user-attachments/assets/c2dd72aa-8d07-4d7f-a713-ebd4b8500a88" />


### Checklist: (Feel free to delete this section upon completion)

- [ ] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have run `yarn run check:code` and all checks pass
- [ ] I have created a changeset for new features, patches, or major changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
