### PR TITLE
Make pan/zoom simultaneous

### DIFF
--- a/.changeset/young-dryers-invite.md
+++ b/.changeset/young-dryers-invite.md
@@ -1,0 +1,5 @@
+---
+"victory-native": patch
+---
+
+Make it possible to zoom/pan simultaneously

--- a/lib/src/cartesian/CartesianChart.tsx
+++ b/lib/src/cartesian/CartesianChart.tsx
@@ -658,19 +658,23 @@ function CartesianChartContent<
 
   let composed = customGestures ?? Gesture.Race();
   if (transformState) {
-    const enablePinch = transformConfig?.pinch?.enabled ?? true;
-    const enablePan = transformConfig?.pan?.enabled ?? true;
+    let gestures = Gesture.Simultaneous();
 
-    const gestures = [
-      ...(enablePinch
-        ? [pinchTransformGesture(transformState, transformConfig?.pinch)]
-        : []),
-      ...(enablePan
-        ? [panTransformGesture(transformState, transformConfig?.pan)]
-        : []),
-    ];
+    if (transformConfig?.pinch?.enabled ?? true) {
+      gestures = Gesture.Simultaneous(
+        gestures,
+        pinchTransformGesture(transformState, transformConfig?.pinch),
+      );
+    }
 
-    composed = Gesture.Race(composed, Gesture.Simultaneous(...gestures));
+    if (transformConfig?.pan?.enabled ?? true) {
+      gestures = Gesture.Simultaneous(
+        gestures,
+        panTransformGesture(transformState, transformConfig?.pan),
+      );
+    }
+
+    composed = Gesture.Race(composed, Gesture.Simultaneous(gestures));
   }
   if (chartPressState) {
     composed = Gesture.Race(composed, panGesture);

--- a/lib/src/cartesian/CartesianChart.tsx
+++ b/lib/src/cartesian/CartesianChart.tsx
@@ -658,18 +658,19 @@ function CartesianChartContent<
 
   let composed = customGestures ?? Gesture.Race();
   if (transformState) {
-    if (transformConfig?.pinch?.enabled ?? true) {
-      composed = Gesture.Race(
-        composed,
-        pinchTransformGesture(transformState, transformConfig?.pinch),
-      );
-    }
-    if (transformConfig?.pan?.enabled ?? true) {
-      composed = Gesture.Race(
-        composed,
-        panTransformGesture(transformState, transformConfig?.pan),
-      );
-    }
+    const enablePinch = transformConfig?.pinch?.enabled ?? true;
+    const enablePan = transformConfig?.pan?.enabled ?? true;
+
+    const gestures = [
+      ...(enablePinch
+        ? [pinchTransformGesture(transformState, transformConfig?.pinch)]
+        : []),
+      ...(enablePan
+        ? [panTransformGesture(transformState, transformConfig?.pan)]
+        : []),
+    ];
+
+    composed = Gesture.Race(composed, Gesture.Simultaneous(...gestures));
   }
   if (chartPressState) {
     composed = Gesture.Race(composed, panGesture);


### PR DESCRIPTION
### Description

We had a lot of issues getting zooming/panning to work correctly, as they raced/cancelled each other. For the most part, panning took precedence, making pinch zooming almost impossible.

This changes it to be simultaneous instead. Other than that, everything should work exactly as before.

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Built the library, injected it into a React Native application and manually confirmed zoom/pan worked

### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [x] I have run `yarn run check:code` and all checks pass
- [x] I have created a changeset for new features, patches, or major changes
- [x] My changes generate no new warnings
