### PR TITLE
fix: prevent empty data from crashing

### DIFF
--- a/.changeset/wet-suns-juggle.md
+++ b/.changeset/wet-suns-juggle.md
@@ -1,0 +1,5 @@
+---
+"victory-native": patch
+---
+
+fix hard crash when data is empty

--- a/lib/src/cartesian/CartesianChart.tsx
+++ b/lib/src/cartesian/CartesianChart.tsx
@@ -55,6 +55,7 @@ import { downsampleTicks } from "../utils/tickHelpers";
 import { GestureHandler } from "../shared/GestureHandler";
 import { boundsToClip } from "../utils/boundsToClip";
 import { normalizeYAxisTicks } from "../utils/normalizeYAxisTicks";
+import { createFallbackChartState } from "./utils/createFallbackChartState";
 
 export type CartesianActionsHandle<T = undefined> =
   T extends ChartPressState<infer S>
@@ -215,6 +216,9 @@ function CartesianChartContent<
     xTicksNormalized,
     _tData,
   } = React.useMemo(() => {
+    if (!data.length) {
+      return createFallbackChartState<RawData, XK, YK>(yKeys);
+    }
     const { xScale, yAxes, isNumericalData, xTicksNormalized, ..._tData } =
       transformInputData({
         data,

--- a/lib/src/cartesian/utils/createFallbackChartState.ts
+++ b/lib/src/cartesian/utils/createFallbackChartState.ts
@@ -1,0 +1,45 @@
+import type {
+  InputFields,
+  NumericalFields,
+  TransformedData,
+} from "../../types";
+import { makeScale } from "./makeScale";
+
+/**
+ * Helper for creating "fallback" chart state if there's no data.
+ * Prevents crashes due to null/empty scales & arrays.
+ */
+export function createFallbackChartState<
+  RawData extends Record<string, unknown>,
+  XK extends keyof InputFields<RawData>,
+  YK extends keyof NumericalFields<RawData>,
+>(yKeys: YK[]) {
+  const fallbackScale = makeScale({
+    inputBounds: [0, 1],
+    outputBounds: [0, 1],
+  });
+
+  return {
+    yAxes: [
+      {
+        yScale: fallbackScale,
+        yTicksNormalized: [],
+      },
+    ],
+    xScale: fallbackScale,
+    chartBounds: { left: 0, right: 0, top: 0, bottom: 0 },
+    isNumericalData: false,
+    xTicksNormalized: [] as number[],
+    _tData: {
+      ix: [],
+      ox: [],
+      y: yKeys.reduce(
+        (acc, key) => {
+          acc[key] = { i: [], o: [] };
+          return acc;
+        },
+        {} as TransformedData<RawData, XK, YK>["y"],
+      ),
+    },
+  };
+}


### PR DESCRIPTION


<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/victory-native-xl/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description
- Prevent hard crash when data array is empty.
- Adds a `createFallbackChartState` fn that will set up a stubbed transform object that will just end up rendering nothing instead.

Fixes #439 

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have run `yarn run check:code` and all checks pass
- [ ] I have created a changeset for new features, patches, or major changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
