### PR TITLE
Add basis curve type to victory-native and update documentation

### DIFF
--- a/.changeset/basis-curve-cange.md
+++ b/.changeset/basis-curve-cange.md
@@ -1,0 +1,5 @@
+---
+"victory-native": patch
+---
+
+Add curve type `basis` for lines

--- a/lib/src/cartesian/utils/curves.ts
+++ b/lib/src/cartesian/utils/curves.ts
@@ -1,4 +1,5 @@
 import {
+  curveBasis,
   curveBumpX,
   curveBumpY,
   curveCardinal,
@@ -24,5 +25,6 @@ export const CURVES = {
   catmullRom100: curveCatmullRom.alpha(1),
   monotoneX: curveMonotoneX,
   step: curveStep,
+  basis: curveBasis,
 } as const;
 export type CurveType = keyof typeof CURVES;

--- a/website/docs/cartesian/area/use-area-path.md
+++ b/website/docs/cartesian/area/use-area-path.md
@@ -60,6 +60,7 @@ The `options` argument object has the following fields:
 - `curveType: CurveType`: the type of curve to use for the path, powered by `d3-shape`. The options are:
   - `linear`
   - `natural`
+  - `basis`
   - `bumpX`
   - `bumpY`
   - `cardinal`


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/victory-native-xl/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description
- Added basis curveType which was avaialble in older version and known for it smooth animation.

Fixes # (issue)

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Tested locally by adding the basis option to the Curve Type section of the Line Chart in the example app — it renders a B-spline interpolation, which produces a smooth, continuous curve.


### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have run `yarn run check:code` and all checks pass
- [x] I have created a changeset for new features, patches, or major changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
