### PR TITLE
chore: add description to package.json to improve visibility

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,7 @@
 {
   "name": "victory-native",
   "version": "41.17.3",
+  "description": "A charting library for React Native with a focus on performance and customization.",
   "private": false,
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
This adds a description to the repo to improve visibility in the React Native Directory.

Currently there's nothing there:  
<img width="1252" alt="Screenshot 2025-06-02 at 19 25 01" src="https://github.com/user-attachments/assets/0fbba3e4-dd48-4d98-9688-34c65eb61246" />


According to the maintainers of the directory, a description is needed in the package.json:
https://github.com/react-native-community/directory/pull/1676#issuecomment-2931353283