### PR TITLE
Update custom-bars.md

### DIFF
--- a/website/docs/cartesian/guides/custom-bars.md
+++ b/website/docs/cartesian/guides/custom-bars.md
@@ -106,9 +106,9 @@ function MyChart() {
                 <LinearGradient
                   start={vec(0, 0)}
                   end={vec(0, 400)}
-                  {/* 👇 using the selected bar, customize children as desired */}
+                  // 👇 using the selected bar, customize children as desired
                   colors={
-                    i == activeXItem
+                    index == activeXItem
                       ? ["green", "blue"]
                       : ["#a78bfa", "#a78bfa50"]
                   }


### PR DESCRIPTION
I found a typo in the `custom-bars` documentation while trying out the example in my app. Not sure if this is too small of a PR - but hoping it helps someone down the line.

`i` is not defined - it should instead be `index`.  Also this comment syntax should use double slashes, not the react style comment syntax.