### PR TITLE
fix: correct package.json exports format for Metro compatibility

### DIFF
--- a/.changeset/brave-cherries-sing.md
+++ b/.changeset/brave-cherries-sing.md
@@ -1,0 +1,5 @@
+---
+"victory-native": minor
+---
+
+fix: update package.json exports format for Metro compatibility

--- a/lib/package.json
+++ b/lib/package.json
@@ -14,13 +14,11 @@
   "types": "dist/index.d.ts",
   "main": "dist/index.js",
   "exports": {
-    ".": [
-      {
-        "imports": "./dist/index.js",
-        "types": "./dist/index.d.ts"
-      },
-      "./dist/index.js"
-    ]
+    ".": {
+      "import": "./dist/index.js",
+      "default": "./src/index.ts",
+      "types": "./dist/index.d.ts"
+    }
   },
   "files": [
     "src",


### PR DESCRIPTION
### Description
Fixes package.json exports format to resolve Metro bundler warnings in Expo SDK 53+. The exports field was using an invalid array/object format that Metro couldn't properly resolve, causing "No export match resolved" warnings.

Fixes #579
Fixes #333

#### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested locally with Expo SDK 53 project - Metro bundler warning no longer appears when importing victory-native modules.

### Checklist:
- [x] I have included a changeset if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [x] I have run `yarn run check:code` and all checks pass
- [x] I have created a changeset for new features, patches, or major changes
- [x] My changes generate no new warnings