### PR TITLE
Feat: add scale logarithmic

### DIFF
--- a/.changeset/lucky-phones-relax.md
+++ b/.changeset/lucky-phones-relax.md
@@ -1,0 +1,5 @@
+---
+"victory-native": minor
+---
+
+Add scale logarithmic to cartesian charts

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "IDX.aI.enableInlineCompletion": true,
-    "IDX.aI.enableCodebaseIndexing": true
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "IDX.aI.enableInlineCompletion": true,
+    "IDX.aI.enableCodebaseIndexing": true
+}

--- a/example/app/line-chart.tsx
+++ b/example/app/line-chart.tsx
@@ -12,6 +12,7 @@ import {
 } from "victory-native";
 import type { AxisLabelPosition } from "lib/src/types";
 import { useDarkMode } from "react-native-dark";
+import type { AxisScaletype } from "lib/src/cartesian/utils/makeScale";
 import { InputSlider } from "example/components/InputSlider";
 import { InputSegment } from "example/components/InputSegment";
 import {
@@ -44,6 +45,7 @@ export default function LineChartPage(props: { segment: string }) {
       strokeWidth,
       xAxisSide,
       yAxisSide,
+      axisScales,
       xLabelOffset,
       yLabelOffset,
       xTickCount,
@@ -84,6 +86,7 @@ export default function LineChartPage(props: { segment: string }) {
           padding={chartPadding}
           yKeys={["sales"]}
           axisOptions={{
+            axisScales,
             font,
             lineWidth: { grid: { x: 0, y: 2 }, frame: 0 },
             lineColor: {
@@ -287,7 +290,6 @@ export default function LineChartPage(props: { segment: string }) {
           value={xAxisSide}
           values={["top", "bottom"]}
         />
-
         <InputSegment<AxisLabelPosition>
           label="X Axis Label position"
           onChange={(val) =>
@@ -338,6 +340,14 @@ export default function LineChartPage(props: { segment: string }) {
           }
           value={yAxisSide}
           values={["left", "right"]}
+        />
+        <InputSegment<AxisScaletype>
+          label="Y Axis scales"
+          onChange={(val) =>
+            dispatch({ type: "SET_AXIS_SCALE", payload: { yAxisScale: val } })
+          }
+          value={axisScales?.yAxisScale || "linear"}
+          values={["linear", "log"]}
         />
         <InputColor
           label="Y-axis Label Color"

--- a/example/app/line-chart.tsx
+++ b/example/app/line-chart.tsx
@@ -10,9 +10,8 @@ import {
   type XAxisSide,
   type YAxisSide,
 } from "victory-native";
-import type { AxisLabelPosition } from "lib/src/types";
+import type { AxisLabelPosition, AxisScaleType } from "lib/src/types";
 import { useDarkMode } from "react-native-dark";
-import type { AxisScaletype } from "lib/src/cartesian/utils/makeScale";
 import { InputSlider } from "example/components/InputSlider";
 import { InputSegment } from "example/components/InputSegment";
 import {
@@ -341,7 +340,7 @@ export default function LineChartPage(props: { segment: string }) {
           value={yAxisSide}
           values={["left", "right"]}
         />
-        <InputSegment<AxisScaletype>
+        <InputSegment<AxisScaleType>
           label="Y Axis scales"
           onChange={(val) =>
             dispatch({ type: "SET_AXIS_SCALE", payload: { yAxisScale: val } })

--- a/example/hooks/useOptionsReducer.ts
+++ b/example/hooks/useOptionsReducer.ts
@@ -1,4 +1,4 @@
-import type { AxisLabelPosition } from "lib/src/types";
+import type { AxisLabelPosition, AxisScales } from "lib/src/types";
 import type { CurveType, XAxisSide, YAxisSide } from "victory-native";
 
 type State = {
@@ -11,6 +11,7 @@ type State = {
   xTickCount: number;
   xAxisSide: XAxisSide;
   yAxisSide: YAxisSide;
+  axisScales: AxisScales;
   scatterRadius: number;
   xAxisLabelPosition: AxisLabelPosition;
   yAxisLabelPosition: AxisLabelPosition;
@@ -33,6 +34,7 @@ type Action =
   | { type: "SET_X_TICK_COUNT"; payload: number }
   | { type: "SET_X_AXIS_SIDE"; payload: XAxisSide }
   | { type: "SET_Y_AXIS_SIDE"; payload: YAxisSide }
+  | { type: "SET_AXIS_SCALE"; payload: AxisScales }
   | { type: "SET_SCATTER_RADIUS"; payload: number }
   | { type: "SET_X_AXIS_LABEL_POSITION"; payload: AxisLabelPosition }
   | { type: "SET_Y_AXIS_LABEL_POSITION"; payload: AxisLabelPosition }
@@ -64,6 +66,8 @@ export const optionsReducer = (state: State, action: Action): State => {
       return { ...state, xAxisSide: action.payload };
     case "SET_Y_AXIS_SIDE":
       return { ...state, yAxisSide: action.payload };
+    case "SET_AXIS_SCALE":
+      return { ...state, axisScales: action.payload };
     case "SET_SCATTER_RADIUS":
       return { ...state, scatterRadius: action.payload };
     case "SET_X_AXIS_LABEL_POSITION":
@@ -101,6 +105,9 @@ export const optionsInitialState: State = {
   scatterRadius: 7,
   xAxisSide: "bottom",
   yAxisSide: "left",
+  axisScales: {
+    yAxisScale: "linear",
+  },
   xAxisLabelPosition: "outset",
   yAxisLabelPosition: "outset",
   colors: {},

--- a/lib/src/cartesian/CartesianChart.tsx
+++ b/lib/src/cartesian/CartesianChart.tsx
@@ -27,10 +27,7 @@ import type {
   Viewport,
   GestureHandlerConfig,
 } from "../types";
-import {
-  transformInputData,
-  type AxisScaleParam,
-} from "./utils/transformInputData";
+import { transformInputData } from "./utils/transformInputData";
 import { findClosestPoint } from "../utils/findClosestPoint";
 import { valueFromSidedNumber } from "../utils/valueFromSidedNumber";
 import { asNumber } from "../utils/asNumber";
@@ -94,7 +91,6 @@ type CartesianChartProps<
     args: CartesianChartRenderArg<RawData, YK>,
   ) => React.ReactNode;
   axisOptions?: Partial<Omit<AxisProps<RawData, XK, YK>, "xScale" | "yScale">>;
-  axisScales?: AxisScaleParam;
   onChartBoundsChange?: (bounds: ChartBounds) => void;
   onScaleChange?: (
     xScale: ScaleLinear<number, number>,
@@ -164,7 +160,6 @@ function CartesianChartContent<
   customGestures,
   actionsRef,
   viewport,
-  axisScales,
 }: CartesianChartProps<RawData, XK, YK>) {
   const [size, setSize] = React.useState({ width: 0, height: 0 });
   const chartBoundsRef = React.useRef<ChartBounds | undefined>(undefined);
@@ -244,7 +239,7 @@ function CartesianChartContent<
         yAxes: normalizedAxisProps.yAxes,
         viewport,
         labelRotate: normalizedAxisProps.xAxis.labelRotate,
-        axisScales,
+        axisScales: axisOptions?.axisScales,
       });
 
     const primaryYAxis = yAxes[0];

--- a/lib/src/cartesian/CartesianChart.tsx
+++ b/lib/src/cartesian/CartesianChart.tsx
@@ -10,7 +10,7 @@ import {
 } from "react-native-gesture-handler";
 import { type MutableRefObject } from "react";
 import { ZoomTransform } from "d3-zoom";
-import type { ScaleLinear } from "d3-scale";
+import type { ScaleLinear, ScaleLogarithmic } from "d3-scale";
 import isEqual from "react-fast-compare";
 import type {
   AxisProps,
@@ -27,7 +27,10 @@ import type {
   Viewport,
   GestureHandlerConfig,
 } from "../types";
-import { transformInputData } from "./utils/transformInputData";
+import {
+  transformInputData,
+  type AxisScaleParam,
+} from "./utils/transformInputData";
 import { findClosestPoint } from "../utils/findClosestPoint";
 import { valueFromSidedNumber } from "../utils/valueFromSidedNumber";
 import { asNumber } from "../utils/asNumber";
@@ -91,7 +94,7 @@ type CartesianChartProps<
     args: CartesianChartRenderArg<RawData, YK>,
   ) => React.ReactNode;
   axisOptions?: Partial<Omit<AxisProps<RawData, XK, YK>, "xScale" | "yScale">>;
-
+  axisScales?: AxisScaleParam;
   onChartBoundsChange?: (bounds: ChartBounds) => void;
   onScaleChange?: (
     xScale: ScaleLinear<number, number>,
@@ -161,12 +164,14 @@ function CartesianChartContent<
   customGestures,
   actionsRef,
   viewport,
+  axisScales,
 }: CartesianChartProps<RawData, XK, YK>) {
   const [size, setSize] = React.useState({ width: 0, height: 0 });
   const chartBoundsRef = React.useRef<ChartBounds | undefined>(undefined);
-  const xScaleRef = React.useRef<ScaleLinear<number, number> | undefined>(
-    undefined,
-  );
+  const xScaleRef = React.useRef<
+    ScaleLogarithmic<number, number> | ScaleLinear<number, number> | undefined
+  >(undefined);
+
   const yScaleRef = React.useRef<ScaleLinear<number, number> | undefined>(
     undefined,
   );
@@ -239,6 +244,7 @@ function CartesianChartContent<
         yAxes: normalizedAxisProps.yAxes,
         viewport,
         labelRotate: normalizedAxisProps.xAxis.labelRotate,
+        axisScales,
       });
 
     const primaryYAxis = yAxes[0];

--- a/lib/src/cartesian/components/CartesianAxis.tsx
+++ b/lib/src/cartesian/components/CartesianAxis.tsx
@@ -251,6 +251,7 @@ export const CartesianAxisDefaultProps = {
   tickCount: 5,
   labelOffset: { x: 2, y: 4 },
   axisSide: { x: "bottom", y: "left" },
+  axisScales: { xAxisScale: "linear", yAxisScale: "linear" },
   labelPosition: "outset",
   formatXLabel: (label: ValueOf<InputDatum>) => String(label),
   formatYLabel: (label: ValueOf<InputDatum>) => String(label),

--- a/lib/src/cartesian/utils/makeScale.ts
+++ b/lib/src/cartesian/utils/makeScale.ts
@@ -4,13 +4,7 @@ import {
   scaleLog,
   type ScaleLogarithmic,
 } from "d3-scale";
-
-const scaleFunctions = {
-  linear: scaleLinear,
-  log: scaleLog,
-};
-
-export type AxisScaletype = keyof typeof scaleFunctions;
+import type { AxisScaleType } from "lib/src/types";
 
 export const makeScale = ({
   inputBounds,
@@ -27,20 +21,30 @@ export const makeScale = ({
   padStart?: number;
   padEnd?: number;
   isNice?: boolean;
-  axisScale?: keyof typeof scaleFunctions;
+  axisScale?: AxisScaleType;
 }): ScaleLinear<number, number> | ScaleLogarithmic<number, number> => {
-  const scaleFunc = scaleFunctions[axisScale];
+  let scale: ScaleLinear<number, number> | ScaleLogarithmic<number, number>;
 
-  // Linear
-
-  //@ts-ignore
-  const viewScale = scaleFunc()
-    .domain(viewport ?? inputBounds)
-    .range(outputBounds);
-  //@ts-ignore
-  const scale = scaleFunc()
-    .domain(inputBounds)
-    .range([viewScale(inputBounds[0]), viewScale(inputBounds[1])]);
+  switch (axisScale) {
+    case "log": {
+      const viewScale = scaleLog()
+        .domain(viewport ?? inputBounds)
+        .range(outputBounds);
+      scale = scaleLog()
+        .domain(inputBounds)
+        .range([viewScale(inputBounds[0]), viewScale(inputBounds[1])]);
+      break;
+    }
+    default: {
+      const viewScale = scaleLinear()
+        .domain(viewport ?? inputBounds)
+        .range(outputBounds);
+      scale = scaleLinear()
+        .domain(inputBounds)
+        .range([viewScale(inputBounds[0]), viewScale(inputBounds[1])]);
+      break;
+    }
+  }
 
   if (padStart || padEnd) {
     scale

--- a/lib/src/cartesian/utils/makeScale.ts
+++ b/lib/src/cartesian/utils/makeScale.ts
@@ -10,7 +10,7 @@ const scaleFunctions = {
   log: scaleLog,
 };
 
-export type AxisScale = keyof typeof scaleFunctions;
+export type AxisScaletype = keyof typeof scaleFunctions;
 
 export const makeScale = ({
   inputBounds,

--- a/lib/src/cartesian/utils/makeScale.ts
+++ b/lib/src/cartesian/utils/makeScale.ts
@@ -1,4 +1,16 @@
-import { type ScaleLinear, scaleLinear } from "d3-scale";
+import {
+  type ScaleLinear,
+  scaleLinear,
+  scaleLog,
+  type ScaleLogarithmic,
+} from "d3-scale";
+
+const scaleFunctions = {
+  linear: scaleLinear,
+  log: scaleLog,
+};
+
+export type AxisScale = keyof typeof scaleFunctions;
 
 export const makeScale = ({
   inputBounds,
@@ -7,6 +19,7 @@ export const makeScale = ({
   padEnd,
   viewport,
   isNice = false,
+  axisScale = "linear",
 }: {
   inputBounds: [number, number];
   outputBounds: [number, number];
@@ -14,12 +27,18 @@ export const makeScale = ({
   padStart?: number;
   padEnd?: number;
   isNice?: boolean;
-}): ScaleLinear<number, number> => {
+  axisScale?: keyof typeof scaleFunctions;
+}): ScaleLinear<number, number> | ScaleLogarithmic<number, number> => {
+  const scaleFunc = scaleFunctions[axisScale];
+
   // Linear
-  const viewScale = scaleLinear()
+
+  //@ts-ignore
+  const viewScale = scaleFunc()
     .domain(viewport ?? inputBounds)
     .range(outputBounds);
-  const scale = scaleLinear()
+  //@ts-ignore
+  const scale = scaleFunc()
     .domain(inputBounds)
     .range([viewScale(inputBounds[0]), viewScale(inputBounds[1])]);
 

--- a/lib/src/cartesian/utils/transformInputData.ts
+++ b/lib/src/cartesian/utils/transformInputData.ts
@@ -14,7 +14,12 @@ import type {
   XAxisPropsWithDefaults,
 } from "../../types";
 import { asNumber } from "../../utils/asNumber";
-import { makeScale } from "./makeScale";
+import { makeScale, type AxisScale } from "./makeScale";
+
+export type AxisScaleParam = {
+  xAxisScale?: AxisScale;
+  yAxisScale?: AxisScale;
+};
 
 /**
  * This is a fatty. Takes raw user input data, and transforms it into a format
@@ -45,6 +50,7 @@ export const transformInputData = <
   yAxes,
   viewport,
   labelRotate,
+  axisScales,
 }: {
   data: RawData[];
   xKey: XK;
@@ -62,6 +68,7 @@ export const transformInputData = <
     y?: [number, number];
   };
   labelRotate?: number;
+  axisScales?: AxisScaleParam;
 }): TransformedData<RawData, XK, YK> & {
   xScale: ScaleLinear<number, number>;
   isNumericalData: boolean;
@@ -73,6 +80,7 @@ export const transformInputData = <
   }>;
 } => {
   const data = [..._data];
+  const { xAxisScale = "linear", yAxisScale = "linear" } = axisScales || {};
 
   // Determine if xKey data is numerical
   const isNumericalData = data.every(
@@ -113,6 +121,7 @@ export const transformInputData = <
   const xTempScale = makeScale({
     inputBounds: ixMin === ixMax ? [ixMin - 1, ixMax + 1] : [ixMin, ixMax],
     outputBounds: [0, rawChartWidth],
+    axisScale: xAxisScale,
   });
 
   // normalize xTicks values either via the d3 scaleLinear ticks() function or our custom downSample function
@@ -228,6 +237,7 @@ export const transformInputData = <
           : domainPadding?.bottom,
       padStart:
         typeof domainPadding === "number" ? domainPadding : domainPadding?.top,
+      axisScale: yAxisScale,
     });
 
     const yData = yKeysForAxis.reduce(
@@ -325,6 +335,7 @@ export const transformInputData = <
       typeof domainPadding === "number" ? domainPadding : domainPadding?.left,
     padEnd:
       typeof domainPadding === "number" ? domainPadding : domainPadding?.right,
+    axisScale: xAxisScale,
   });
 
   // Normalize xTicks values either via the d3 scaleLinear ticks() function or our custom downSample function

--- a/lib/src/cartesian/utils/transformInputData.ts
+++ b/lib/src/cartesian/utils/transformInputData.ts
@@ -14,11 +14,11 @@ import type {
   XAxisPropsWithDefaults,
 } from "../../types";
 import { asNumber } from "../../utils/asNumber";
-import { makeScale, type AxisScale } from "./makeScale";
+import { makeScale, type AxisScaletype } from "./makeScale";
 
-export type AxisScaleParam = {
-  xAxisScale?: AxisScale;
-  yAxisScale?: AxisScale;
+export type AxisScales = {
+  xAxisScale?: AxisScaletype;
+  yAxisScale?: AxisScaletype;
 };
 
 /**
@@ -68,7 +68,7 @@ export const transformInputData = <
     y?: [number, number];
   };
   labelRotate?: number;
-  axisScales?: AxisScaleParam;
+  axisScales?: AxisScales;
 }): TransformedData<RawData, XK, YK> & {
   xScale: ScaleLinear<number, number>;
   isNumericalData: boolean;

--- a/lib/src/cartesian/utils/transformInputData.ts
+++ b/lib/src/cartesian/utils/transformInputData.ts
@@ -12,14 +12,10 @@ import type {
   NonEmptyArray,
   YAxisPropsWithDefaults,
   XAxisPropsWithDefaults,
+  AxisScales,
 } from "../../types";
 import { asNumber } from "../../utils/asNumber";
-import { makeScale, type AxisScaletype } from "./makeScale";
-
-export type AxisScales = {
-  xAxisScale?: AxisScaletype;
-  yAxisScale?: AxisScaletype;
-};
+import { makeScale } from "./makeScale";
 
 /**
  * This is a fatty. Takes raw user input data, and transforms it into a format

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -12,6 +12,7 @@ import type {
   UserSelect,
   TouchAction,
 } from "react-native-gesture-handler/lib/typescript/handlers/gestureHandlerCommon";
+import type { AxisScaletype } from "./cartesian/utils/makeScale";
 
 export type PrimitiveViewWindow = {
   xMin: number;
@@ -34,6 +35,11 @@ export type InputDatum = Record<string, unknown>;
 export type XAxisSide = "top" | "bottom";
 export type YAxisSide = "left" | "right";
 export type AxisLabelPosition = "inset" | "outset";
+
+export type AxisScales = {
+  xAxisScale?: AxisScaletype;
+  yAxisScale?: AxisScaletype;
+};
 
 export type ScatterOptions = {
   radius: number;
@@ -125,6 +131,7 @@ export type AxisProps<
   yTicksNormalized: number[];
   xScale: ScaleLinear<number, number, never>;
   yScale: ScaleLinear<number, number, never>;
+  axisScales?: AxisScales;
   font?: SkFont | null;
   lineColor?: Color | { grid: Color | { x: Color; y: Color }; frame: Color };
   lineWidth?:

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -12,7 +12,6 @@ import type {
   UserSelect,
   TouchAction,
 } from "react-native-gesture-handler/lib/typescript/handlers/gestureHandlerCommon";
-import type { AxisScaletype } from "./cartesian/utils/makeScale";
 
 export type PrimitiveViewWindow = {
   xMin: number;
@@ -36,9 +35,11 @@ export type XAxisSide = "top" | "bottom";
 export type YAxisSide = "left" | "right";
 export type AxisLabelPosition = "inset" | "outset";
 
+export type AxisScaleType = "linear" | "log";
+
 export type AxisScales = {
-  xAxisScale?: AxisScaletype;
-  yAxisScale?: AxisScaletype;
+  xAxisScale?: AxisScaleType;
+  yAxisScale?: AxisScaleType;
 };
 
 export type ScatterOptions = {


### PR DESCRIPTION

### Description

allows users to pass in a axisOptions -> axisScales -> linear | log prop to enable the usage of lagarithsm charts

#### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### How Has This Been Tested?

Enhance an example -> example/app/line-chart.tsx

### Checklist:

- [x] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have run `yarn run check:code` and all checks pass
- [ ] I have created a changeset for new features, patches, or major changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
