### PR TITLE
Feature/bar label rotation and format

### DIFF
--- a/example/app/bar-chart.tsx
+++ b/example/app/bar-chart.tsx
@@ -128,7 +128,13 @@ export default function BarChartPage(props: { segment: string }) {
                     topLeft: roundedCorner,
                     topRight: roundedCorner,
                   }}
-                  labels={{ font, color: labelColor, position: labelPosition }}
+                  labels={{
+                    font,
+                    color: labelColor,
+                    position: labelPosition,
+                    labelRotate: 270,
+                    format: (v) => `$${Number(v)}`,
+                  }}
                 >
                   <LinearGradient
                     start={vec(0, 0)}

--- a/lib/src/cartesian/components/BarGraphLabels.tsx
+++ b/lib/src/cartesian/components/BarGraphLabels.tsx
@@ -7,6 +7,8 @@ export type BarLabelConfig = {
   position: "top" | "bottom" | "left" | "right";
   font: SkFont | null;
   color?: Color;
+  labelRotate?: number;
+  format?: (value: number | string) => string;
 };
 
 type BarGraphLabelProps = {
@@ -29,7 +31,11 @@ export const BarGraphLabels = ({
 
   // Loop over the data points and position each label
   return points.map(({ x, y = 0, yValue }) => {
-    const yText = yValue?.toString() ?? "";
+    // Format labels, if a format function is provided
+    const yText = options.format
+      ? options.format(yValue ? yValue : "")
+      : yValue?.toString() ?? "";
+
     const labelWidth = getFontGlyphWidth(yText, font);
 
     let xOffset;
@@ -46,19 +52,19 @@ export const BarGraphLabels = ({
     // Bar Midpoints
     const barVerticalMidpoint =
       (chartInnerTopEdge + chartInnerBottomEdge + Number(y)) / 2;
-    const barHorizontalMidpoint = x - labelWidth / 2;
+    // Move the label left by half its width to properly center the text over the bar
+    // const barHorizontalMidpoint = x - labelWidth / 2;
 
     switch (position) {
       case "top": {
         // Position the label above the bar
-        // Move the label left by half its width to properly center the text over the bar
-        xOffset = barHorizontalMidpoint;
+        xOffset = x;
         yOffset = Number(y) - LABEL_OFFSET_FROM_POSITION;
         break;
       }
       case "bottom": {
         // Position the label at the bottom of the bar
-        xOffset = barHorizontalMidpoint;
+        xOffset = x;
         // Use the chartBounds here so that the label isn't rendered under the graph
         yOffset = chartInnerBottomEdge - LABEL_OFFSET_FROM_POSITION;
         break;
@@ -92,6 +98,17 @@ export const BarGraphLabels = ({
         text={yText}
         font={font}
         color={color}
+        // Rotation of the label
+        transform={
+          options.labelRotate !== undefined
+            ? [{ rotate: (options.labelRotate * Math.PI) / 180 }]
+            : undefined
+        }
+        origin={
+          options.labelRotate !== undefined
+            ? { x: xOffset, y: yOffset }
+            : undefined
+        }
       />
     );
   });

--- a/website/docs/cartesian/bar/bar.md
+++ b/website/docs/cartesian/bar/bar.md
@@ -73,6 +73,8 @@ The `labels` prop allows you to enable and customize the data label of the Bar c
 - `position: "top" | "bottom" | "left" | "right"`: Defines where the Bar component data label should be rendered in relationship to the rendered Bar component.
 - `font: SkFont | null`: Defines the font to use with the Skia `Text` component.
 - `color?: Color`: Defines the color the data label should be.
+- `labelRotate?: number`: Defines the rotation angle of the data label in degrees.
+- `format?: (value: number) => string`: Defines a function that formats the data label text. It receives the Y-axis value as an argument and should return a string. If not provided, the default is to convert the Y-axis value to a string.
 
 ### `children`
 


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/victory-native-xl/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

This PR adds 2 new options to the label prop of the Bar component:
- `labelRotate`: To rotate the label using dregees.
- `format`: To be able to add a prefix or suffix to the label element of the bar chart.

Fixes issue https://github.com/FormidableLabs/victory-native-xl/issues/528

#### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

To test its function, I updated the example, bar-chart.tsx screen and tried with:
- Different rotation degrees, while modifying the label position mostly in bottom and top options.
- Added a simple prefix to the label.

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have run `yarn run check:code` and all checks pass
- [x] My changes generate no new warnings


<!--
I think the following checklists are not needed, but need to review
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages. 
- [ ] I have created a changeset for new features, patches, or major changes
- [ ] Any dependent changes have been merged and published in downstream modules
-->