### PR TITLE
Replace onLayout with ref to measure Canvas size

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -14,7 +14,7 @@
     "@gorhom/bottom-sheet": "^4",
     "@react-native-community/slider": "4.5.6",
     "@react-native-segmented-control/segmented-control": "2.5.7",
-    "@shopify/react-native-skia": "2.0.2",
+    "@shopify/react-native-skia": "2.2.2",
     "canvaskit-wasm": "^0.40.0",
     "d3-scale": "^4.0.2",
     "date-fns": "^2.30.0",

--- a/package.json
+++ b/package.json
@@ -41,5 +41,6 @@
   },
   "engines": {
     "node": ">=20"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2322,10 +2322,10 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.17.1.tgz#e672de70ce490e5564fe75171373d1653b5694da"
   integrity sha512-0QbCkfk6cnnVKWqqlC0cUrrUMDMfu5ffvYMTUHf+qMN2uAb3MKP31LPcwiMXBNsvoFGs/kYdFOsuLmvppCopXA==
 
-"@shopify/react-native-skia@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-2.0.2.tgz#45180cc37b04325165ba995c23a7fae2c2b911a1"
-  integrity sha512-1/mdPHT/EUcJEdj+HkRqv+Hu40IvYXlyxn5F8G18ix6Ab27Gj58himYU7g6kXKRgSUZ9g5w63ouPcXQITHHXOw==
+"@shopify/react-native-skia@2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-2.2.2.tgz#eb8f762253509b000e7bbb2b8ce2b5508ab7b91f"
+  integrity sha512-5cAmTLdTi/ihH5iyyfBefWD7xhqPhMBBsy/za9+WrF4vXwWpsRXABQJbiz88rDpMsN9GCtEzI4p9pEP3fHRRGQ==
   dependencies:
     canvaskit-wasm "0.40.0"
     react-reconciler "0.31.0"


### PR DESCRIPTION
### Description

Since `react-native-skia@2.2.x`, the `onLayout` prop is no longer available on the `Canvas` component. We now retrieve the size using a `ref` on the Canvas.

Fixes: https://github.com/FormidableLabs/victory-native-xl/issues/604

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Note:** Users must upgrade `react-native-skia` to version `2.2.2` or later.

### How Has This Been Tested?

I verified that both Polar and Cartesian charts render at the correct size.  
To minimize changes, the size is now retrieved using a Canvas `ref`, and the `onLayout` logic is preserved inside a `useLayoutEffect`, as recommended by the RN Skia team:  
https://shopify.github.io/react-native-skia/docs/canvas/overview#canvas-size

### Checklist

- [ ] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have run `yarn run check:code` and all checks pass
- [ ] I have created a changeset for new features, patches, or major changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

### Notes

Some ESLint warnings may appear regarding `useLayoutEffect` dependencies (`ref`, `onLayout`).  
Since both values are stable, these warnings can be safely ignored using `// eslint-disable-next-line react-hooks/exhaustive-deps`.
