### PR TITLE
Feat/new line curve type

### DIFF
--- a/.changeset/fair-lies-pump.md
+++ b/.changeset/fair-lies-pump.md
@@ -1,0 +1,6 @@
+---
+"victory-native": minor
+"example": minor
+---
+
+Add `stepAfter` and `stepBefore` to the line curve options

--- a/lib/src/cartesian/utils/curves.ts
+++ b/lib/src/cartesian/utils/curves.ts
@@ -8,6 +8,8 @@ import {
   curveMonotoneX,
   curveNatural,
   curveStep,
+  curveStepAfter,
+  curveStepBefore,
 } from "d3-shape";
 
 /**
@@ -25,6 +27,8 @@ export const CURVES = {
   catmullRom100: curveCatmullRom.alpha(1),
   monotoneX: curveMonotoneX,
   step: curveStep,
+  stepAfter: curveStepAfter,
+  stepBefore: curveStepBefore,
   basis: curveBasis,
 } as const;
 export type CurveType = keyof typeof CURVES;

--- a/website/docs/cartesian/area/use-area-path.md
+++ b/website/docs/cartesian/area/use-area-path.md
@@ -70,6 +70,8 @@ The `options` argument object has the following fields:
   - `catmullRom100`
   - `monotoneX`
   - `step`
+  - `stepAfter`
+  - `stepBefore`
 - `connectMissingData: boolean`: whether or not to interpolate missing data for this path (default is `false`). If set to `true`, the output will be a single, connected path (even if there are missing data values).
 
 ## Returns

--- a/website/docs/cartesian/line/use-line-path.md
+++ b/website/docs/cartesian/line/use-line-path.md
@@ -52,6 +52,8 @@ The `options` argument object has the following fields:
   - `catmullRom0`
   - `catmullRom100`
   - `step`
+  - `stepAfter`
+  - `stepBefore`
 - `connectMissingData: boolean`: whether or not to interpolate missing data for this path (default is `false`). If set to `true`, the output will be a single, connected path (even if there are missing data values).
 
 ## Returns


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/victory-native-xl/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

This PR adds two new curve types available on d3-shape, extending the options to create step charts. This adds `stepAfter` and `stepBefore` using the functions [curveStepAfter](https://d3js.org/d3-shape/curve#curveStepAfter) and [curveStepBefore](https://d3js.org/d3-shape/curve#curveStepBefore)


#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### How Has This Been Tested?

Using the example project, changing the line chart curve type. The changes that I made to test were not added to this MR.

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have run `yarn run check:code` and all checks pass
- [x] I have created a changeset for new features, patches, or major changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
