### PR TITLE
Correct component name for Pie Slice example

### DIFF
--- a/website/docs/polar/pie/pie-slice.md
+++ b/website/docs/polar/pie/pie-slice.md
@@ -10,7 +10,7 @@ The [example app](https://github.com/FormidableLabs/victory-native-xl/tree/main/
 
 ## Example
 
-The example below shows how to use `Pie.SliceAngularInset` to render `LinearGradient` slices.
+The example below shows how to use `Pie.Slice` to render `LinearGradient` slices.
 
 ```tsx
 import { View } from "react-native";


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/victory-native-xl/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

This PR fixes a small documentation error in the `Pie.Slice` example.

In `website/docs/polar/pie/pie-slice.md`, the description previously referred to `Pie.SliceAngularInset` in an example that actually demonstrates `Pie.Slice`. This change corrects the reference so the docs accurately match the code snippet.

Motivation was that I was using victory native xl for the first time, so reading the docs to understand how to use the Pie.Slice component. This mistake confused me for a second, so don't want other beginners to get lost on this.

Fixes # (no issue filed, just a doc correction I noticed while using the library)

#### Type of Change

- [x] This change requires a documentation update

### How Has This Been Tested?

I ran the docs locally to verify that the updated text renders correctly. The example code snippet remains unchanged and works as before. As well as `yarn check:code` and `yarn test` as stated in the contributing guide.
