### PR TITLE
feat(axis): Add multiline axis label support with proper spacing

### DIFF
--- a/.changeset/multiline-axis.md
+++ b/.changeset/multiline-axis.md
@@ -1,0 +1,6 @@
+---
+"example": patch
+"victory-native": patch
+---
+
+Add multiline axis label support with proper spacing and layout handling.

--- a/example/app/multiline-axis.tsx
+++ b/example/app/multiline-axis.tsx
@@ -1,0 +1,137 @@
+import { useFont } from "@shopify/react-native-skia";
+import * as React from "react";
+import { SafeAreaView, ScrollView, StyleSheet, View } from "react-native";
+import { CartesianChart, Line, Scatter } from "victory-native";
+import { useDarkMode } from "react-native-dark";
+import inter from "../assets/inter-medium.ttf";
+import { appColors } from "../consts/colors";
+import { InfoCard } from "../components/InfoCard";
+import { descriptionForRoute } from "../consts/routes";
+
+const DATA = Array.from({ length: 6 }, (_, index) => ({
+  month: index,
+  sales: Math.random() * 100 + 50,
+  profit: Math.random() * 50 + 25,
+}));
+
+const MONTH_NAMES = [
+  "January\n2024",
+  "February\n2024",
+  "March\n2024",
+  "April\n2024",
+  "May\n2024",
+  "June\n2024",
+];
+
+const METRIC_LABELS = [
+  "Low\nPerformance",
+  "Below\nAverage",
+  "Average\nPerformance",
+  "Good\nPerformance",
+  "Excellent\nPerformance",
+];
+
+export default function MultilineAxis(props: { segment: string }) {
+  const description = descriptionForRoute(props.segment);
+  const isDark = useDarkMode();
+  const font = useFont(inter, 12);
+
+  return (
+    <SafeAreaView style={styles.safeView}>
+      <View style={styles.chart}>
+        <CartesianChart
+          xKey="month"
+          padding={20}
+          yKeys={["sales", "profit"]}
+          data={DATA}
+          xAxis={{
+            font,
+            labelColor: isDark ? appColors.text.dark : appColors.text.light,
+            formatXLabel: (value) =>
+              MONTH_NAMES[value as number] || `Month ${value}`,
+            labelOffset: 8,
+          }}
+          yAxis={[
+            {
+              font,
+              labelColor: isDark ? appColors.text.dark : appColors.text.light,
+              formatYLabel: (value) => {
+                const index = Math.floor((value as number) / 25);
+                return (
+                  METRIC_LABELS[Math.min(index, METRIC_LABELS.length - 1)] ||
+                  `${value}`
+                );
+              },
+              labelOffset: 8,
+              yKeys: ["sales", "profit"],
+            },
+          ]}
+        >
+          {({ points }) => (
+            <>
+              <Line
+                points={points.sales}
+                color="#8b5cf6"
+                strokeWidth={3}
+                animate={{ type: "spring" }}
+              />
+              <Line
+                points={points.profit}
+                color="#06b6d4"
+                strokeWidth={3}
+                animate={{ type: "spring" }}
+              />
+              <Scatter
+                radius={4}
+                points={points.sales}
+                animate={{ type: "spring" }}
+                color="#8b5cf6"
+              />
+              <Scatter
+                radius={4}
+                points={points.profit}
+                animate={{ type: "spring" }}
+                color="#06b6d4"
+              />
+            </>
+          )}
+        </CartesianChart>
+      </View>
+      <ScrollView
+        style={styles.optionsScrollView}
+        contentContainerStyle={styles.options}
+      >
+        <InfoCard>
+          {description ||
+            "This example demonstrates multiline axis labels. X-axis shows months with years on separate lines, while Y-axis shows performance categories with descriptive text on multiple lines. Use \\n in your formatXLabel or formatYLabel functions to create multiline labels."}
+        </InfoCard>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeView: {
+    flex: 1,
+    backgroundColor: appColors.viewBackground.light,
+    $dark: {
+      backgroundColor: appColors.viewBackground.dark,
+    },
+  },
+  chart: {
+    flex: 1,
+  },
+  optionsScrollView: {
+    flex: 0.3,
+    backgroundColor: appColors.cardBackground.light,
+    $dark: {
+      backgroundColor: appColors.cardBackground.dark,
+    },
+  },
+  options: {
+    paddingHorizontal: 20,
+    paddingVertical: 15,
+    alignItems: "flex-start",
+    justifyContent: "flex-start",
+  },
+});

--- a/example/consts/routes.ts
+++ b/example/consts/routes.ts
@@ -158,6 +158,11 @@ export const ChartRoutes: {
     description: "This example demonstrates chart interactions using refs.",
     path: "/chart-refs",
   },
+  {
+    title: "Multiline Axis Labels",
+    description: "Example demonstrating multiline axis labels using both newline characters and string arrays.",
+    path: "/multiline-axis",
+  },
 ];
 
 if (__DEV__) {

--- a/example/consts/routes.ts
+++ b/example/consts/routes.ts
@@ -160,7 +160,8 @@ export const ChartRoutes: {
   },
   {
     title: "Multiline Axis Labels",
-    description: "Example demonstrating multiline axis labels using both newline characters and string arrays.",
+    description:
+      "Example demonstrating multiline axis labels using both newline characters and string arrays.",
     path: "/multiline-axis",
   },
 ];

--- a/lib/src/cartesian/CartesianChart.tsx
+++ b/lib/src/cartesian/CartesianChart.tsx
@@ -295,6 +295,7 @@ function CartesianChartContent<
     domainPadding,
     normalizedAxisProps,
     viewport,
+    axisOptions?.axisScales,
   ]);
 
   React.useEffect(() => {

--- a/lib/src/cartesian/components/CartesianAxis.tsx
+++ b/lib/src/cartesian/components/CartesianAxis.tsx
@@ -121,24 +121,15 @@ export const CartesianAxis = <
 
   const yAxisNodes = yTicksNormalized.map((tick) => {
     const contentY = formatYLabel(tick as never);
-    const labelWidth = getFontGlyphWidth(contentY, font);
+
+    // Handle both string and string array formats for multiline labels
+    const lines = Array.isArray(contentY) ? contentY : contentY.split("\n");
+
+    // Calculate width for each line and find the max width
+    const lineWidths = lines.map((line: string) =>
+      getFontGlyphWidth(line, font),
+    );
     const labelY = yScale(tick) + fontSize / 3;
-    const labelX = (() => {
-      // left, outset
-      if (yAxisPosition === "left" && yLabelPosition === "outset") {
-        return xScale(x1) - (labelWidth + yLabelOffset);
-      }
-      // left, inset
-      if (yAxisPosition === "left" && yLabelPosition === "inset") {
-        return xScale(x1) + yLabelOffset;
-      }
-      // right, outset
-      if (yAxisPosition === "right" && yLabelPosition === "outset") {
-        return xScale(x2) + yLabelOffset;
-      }
-      // right, inset
-      return xScale(x2) - (labelWidth + yLabelOffset);
-    })();
 
     const canFitLabelContent = labelY > fontSize && labelY < yScale(y2);
 
@@ -154,15 +145,55 @@ export const CartesianAxis = <
         ) : null}
         {font
           ? canFitLabelContent && (
-              <Text
-                color={
-                  typeof labelColor === "string" ? labelColor : labelColor.y
-                }
-                text={contentY}
-                font={font}
-                y={labelY}
-                x={labelX}
-              />
+              <>
+                {lines.map((line: string, lineIndex: number) => {
+                  // Calculate x position for each line based on line width
+                  const lineWidth = lineWidths[lineIndex];
+                  const lineLabelX = (() => {
+                    // left, outset
+                    if (
+                      yAxisPosition === "left" &&
+                      yLabelPosition === "outset"
+                    ) {
+                      return xScale(x1) - ((lineWidth || 0) + yLabelOffset);
+                    }
+                    // left, inset
+                    if (
+                      yAxisPosition === "left" &&
+                      yLabelPosition === "inset"
+                    ) {
+                      return xScale(x1) + yLabelOffset;
+                    }
+                    // right, outset
+                    if (
+                      yAxisPosition === "right" &&
+                      yLabelPosition === "outset"
+                    ) {
+                      return xScale(x2) + yLabelOffset;
+                    }
+                    // right, inset
+                    return xScale(x2) - ((lineWidth || 0) + yLabelOffset);
+                  })();
+
+                  // Calculate y position for each line
+                  const lineY = labelY + lineIndex * fontSize;
+
+                  return (
+                    <Text
+                      key={`y-line-${lineIndex}`}
+                      color={
+                        typeof labelColor === "string"
+                          ? labelColor
+                          : labelColor.y
+                      }
+                      text={line}
+                      font={font}
+                      y={lineY}
+                      x={lineLabelX}
+                    />
+                  );
+                })}
+              </>
             )
           : null}
       </React.Fragment>
@@ -172,7 +203,15 @@ export const CartesianAxis = <
   const xAxisNodes = xTicksNormalized.map((tick) => {
     const val = isNumericalData ? tick : ix[tick];
     const contentX = formatXLabel(val as never);
-    const labelWidth = getFontGlyphWidth(contentX, font);
+
+    // Handle both string and string array formats for multiline labels
+    const lines = Array.isArray(contentX) ? contentX : contentX.split("\n");
+
+    // Calculate width for each line and find the max width
+    const lineWidths = lines.map((line: string) =>
+      getFontGlyphWidth(line, font),
+    );
+    const labelWidth = Math.max(...lineWidths, 0);
     const labelX = xScale(tick) - (labelWidth ?? 0) / 2;
     const canFitLabelContent =
       yAxisPosition === "left" ? labelX + labelWidth < x2r : x1r < labelX;
@@ -205,13 +244,28 @@ export const CartesianAxis = <
           />
         ) : null}
         {font && labelWidth && canFitLabelContent ? (
-          <Text
-            color={typeof labelColor === "string" ? labelColor : labelColor.x}
-            text={contentX}
-            font={font}
-            y={labelY}
-            x={labelX}
-          />
+          <>
+            {lines.map((line: string, lineIndex: number) => {
+              // Calculate x position for center alignment
+              const lineWidth = lineWidths[lineIndex];
+              const lineLabelX = xScale(tick) - (lineWidth || 0) / 2;
+              // Calculate y position for each line
+              const lineY = labelY + lineIndex * fontSize;
+
+              return (
+                <Text
+                  key={`x-line-${lineIndex}`}
+                  color={
+                    typeof labelColor === "string" ? labelColor : labelColor.x
+                  }
+                  text={line}
+                  font={font}
+                  y={lineY}
+                  x={lineLabelX}
+                />
+              );
+            })}
+          </>
         ) : null}
       </React.Fragment>
     );

--- a/lib/src/cartesian/components/XAxis.tsx
+++ b/lib/src/cartesian/components/XAxis.tsx
@@ -59,10 +59,18 @@ export const XAxis = <
     const val = isNumericalData ? tick : ix[tick];
 
     const contentX = formatXLabel(val as never);
-    const labelWidth =
-      font
-        ?.getGlyphWidths?.(font.getGlyphIDs(contentX))
-        .reduce((sum, value) => sum + value, 0) ?? 0;
+
+    // Handle both string and string array formats for multiline labels
+    const lines = Array.isArray(contentX) ? contentX : contentX.split("\n");
+
+    // Calculate width for each line and find the max width
+    const lineWidths = lines.map(
+      (line: string) =>
+        font
+          ?.getGlyphWidths?.(font.getGlyphIDs(line))
+          .reduce((sum, value) => sum + value, 0) ?? 0,
+    );
+    const labelWidth = Math.max(...lineWidths, 0);
     const labelX = xScale(tick) - (labelWidth ?? 0) / 2;
     const canFitLabelContent =
       xScale(tick) >= chartBounds.left &&
@@ -139,19 +147,30 @@ export const XAxis = <
         ) : null}
         {font && labelWidth && canFitLabelContent ? (
           <Group transform={[{ translateY: rotateOffset }]}>
-            <Text
-              transform={[
-                {
-                  rotate: (Math.PI / 180) * (labelRotate ?? 0),
-                },
-              ]}
-              origin={origin}
-              color={labelColor}
-              text={contentX}
-              font={font}
-              y={labelY}
-              x={labelX}
-            />
+            {lines.map((line: string, lineIndex: number) => {
+              // Calculate x position for center alignment
+              const lineWidth = lineWidths[lineIndex];
+              const lineLabelX = xScale(tick) - (lineWidth || 0) / 2;
+              // Calculate y position for each line
+              const lineY = labelY + lineIndex * fontSize;
+
+              return (
+                <Text
+                  key={`line-${lineIndex}`}
+                  transform={[
+                    {
+                      rotate: (Math.PI / 180) * (labelRotate ?? 0),
+                    },
+                  ]}
+                  origin={origin}
+                  color={labelColor}
+                  text={line}
+                  font={font}
+                  y={lineY}
+                  x={lineLabelX}
+                />
+              );
+            })}
           </Group>
         ) : null}
         <></>

--- a/lib/src/cartesian/components/YAxis.tsx
+++ b/lib/src/cartesian/components/YAxis.tsx
@@ -33,27 +33,19 @@ export const YAxis = <
   const fontSize = font?.getSize() ?? 0;
   const yAxisNodes = yTicksNormalized.map((tick) => {
     const contentY = formatYLabel(tick as never);
-    const labelWidth =
-      font
-        ?.getGlyphWidths?.(font.getGlyphIDs(contentY))
-        .reduce((sum, value) => sum + value, 0) ?? 0;
+
+    // Handle both string and string array formats for multiline labels
+    const lines = Array.isArray(contentY) ? contentY : contentY.split("\n");
+
+    // Calculate width for each line and find the max width
+    const lineWidths = lines.map(
+      (line: string) =>
+        font
+          ?.getGlyphWidths?.(font.getGlyphIDs(line))
+          .reduce((sum, value) => sum + value, 0) ?? 0,
+    );
+
     const labelY = yScale(tick) + fontSize / 3;
-    const labelX = (() => {
-      // left, outset
-      if (axisSide === "left" && labelPosition === "outset") {
-        return chartBounds.left - (labelWidth + labelOffset);
-      }
-      // left, inset
-      if (axisSide === "left" && labelPosition === "inset") {
-        return chartBounds.left + labelOffset;
-      }
-      // right, outset
-      if (axisSide === "right" && labelPosition === "outset") {
-        return chartBounds.right + labelOffset;
-      }
-      // right, inset
-      return chartBounds.right - (labelWidth + labelOffset);
-    })();
 
     const canFitLabelContent = labelY > fontSize && labelY < yScale(y2);
 
@@ -73,13 +65,44 @@ export const YAxis = <
         ) : null}
         {font
           ? canFitLabelContent && (
-              <Text
-                color={labelColor}
-                text={contentY}
-                font={font}
-                y={labelY}
-                x={labelX}
-              />
+              <>
+                {lines.map((line: string, lineIndex: number) => {
+                  // Calculate x position for each line based on line width
+                  const lineWidth = lineWidths[lineIndex];
+                  const lineLabelX = (() => {
+                    // left, outset
+                    if (axisSide === "left" && labelPosition === "outset") {
+                      return (
+                        chartBounds.left - ((lineWidth || 0) + labelOffset)
+                      );
+                    }
+                    // left, inset
+                    if (axisSide === "left" && labelPosition === "inset") {
+                      return chartBounds.left + labelOffset;
+                    }
+                    // right, outset
+                    if (axisSide === "right" && labelPosition === "outset") {
+                      return chartBounds.right + labelOffset;
+                    }
+                    // right, inset
+                    return chartBounds.right - ((lineWidth || 0) + labelOffset);
+                  })();
+
+                  // Calculate y position for each line
+                  const lineY = labelY + lineIndex * fontSize;
+
+                  return (
+                    <Text
+                      key={`line-${lineIndex}`}
+                      color={labelColor}
+                      text={line}
+                      font={font}
+                      y={lineY}
+                      x={lineLabelX}
+                    />
+                  );
+                })}
+              </>
             )
           : null}
       </React.Fragment>

--- a/lib/src/cartesian/utils/transformInputData.ts
+++ b/lib/src/cartesian/utils/transformInputData.ts
@@ -133,11 +133,17 @@ export const transformInputData = <
             xTick as unknown as Parameters<typeof xAxis.formatXLabel>[0],
           )
         : String(xTick);
-      const labelStr = String(labelValue);
-      if (!xAxis.font) return 0;
-      const glyphIDs = xAxis.font.getGlyphIDs(labelStr);
-      const widths = xAxis.font.getGlyphWidths?.(glyphIDs) ?? [];
-      return widths.reduce((sum, w) => sum + w, 0);
+      
+      // Handle multiline labels by finding the width of the longest line
+      const lines = Array.isArray(labelValue) ? labelValue : String(labelValue).split("\n");
+      const lineWidths = lines.map((line: string) => {
+        if (!xAxis.font) return 0;
+        const glyphIDs = xAxis.font.getGlyphIDs(line);
+        const widths = xAxis.font.getGlyphWidths?.(glyphIDs) ?? [];
+        return widths.reduce((sum, w) => sum + w, 0);
+      });
+      
+      return Math.max(...lineWidths, 0);
     }),
   );
 
@@ -269,14 +275,21 @@ export const transformInputData = <
 
     const maxYLabel = Math.max(
       ...yTicksNormalized.map(
-        (yTick) =>
-          yAxis?.font
-            ?.getGlyphWidths?.(
-              yAxis.font.getGlyphIDs(
-                yAxis?.formatYLabel?.(yTick as RawData[YK]) || String(yTick),
-              ),
-            )
-            .reduce((sum, value) => sum + value, 0) ?? 0,
+        (yTick) => {
+          const label =
+            yAxis?.formatYLabel?.(yTick as RawData[YK]) ||
+            String(yTick);
+          
+          // Handle multiline labels by finding the width of the longest line
+          const lines = Array.isArray(label) ? label : label.split("\n");
+          const lineWidths = lines.map((line: string) =>
+            yAxis?.font
+              ?.getGlyphWidths?.(yAxis.font.getGlyphIDs(line))
+              .reduce((sum, value) => sum + value, 0) ?? 0
+          );
+          
+          return Math.max(...lineWidths, 0);
+        },
       ),
     );
 

--- a/lib/src/cartesian/utils/transformInputData.ts
+++ b/lib/src/cartesian/utils/transformInputData.ts
@@ -133,16 +133,18 @@ export const transformInputData = <
             xTick as unknown as Parameters<typeof xAxis.formatXLabel>[0],
           )
         : String(xTick);
-      
+
       // Handle multiline labels by finding the width of the longest line
-      const lines = Array.isArray(labelValue) ? labelValue : String(labelValue).split("\n");
+      const lines = Array.isArray(labelValue)
+        ? labelValue
+        : String(labelValue).split("\n");
       const lineWidths = lines.map((line: string) => {
         if (!xAxis.font) return 0;
         const glyphIDs = xAxis.font.getGlyphIDs(line);
         const widths = xAxis.font.getGlyphWidths?.(glyphIDs) ?? [];
         return widths.reduce((sum, w) => sum + w, 0);
       });
-      
+
       return Math.max(...lineWidths, 0);
     }),
   );
@@ -274,23 +276,21 @@ export const transformInputData = <
     });
 
     const maxYLabel = Math.max(
-      ...yTicksNormalized.map(
-        (yTick) => {
-          const label =
-            yAxis?.formatYLabel?.(yTick as RawData[YK]) ||
-            String(yTick);
-          
-          // Handle multiline labels by finding the width of the longest line
-          const lines = Array.isArray(label) ? label : label.split("\n");
-          const lineWidths = lines.map((line: string) =>
+      ...yTicksNormalized.map((yTick) => {
+        const label =
+          yAxis?.formatYLabel?.(yTick as RawData[YK]) || String(yTick);
+
+        // Handle multiline labels by finding the width of the longest line
+        const lines = Array.isArray(label) ? label : label.split("\n");
+        const lineWidths = lines.map(
+          (line: string) =>
             yAxis?.font
               ?.getGlyphWidths?.(yAxis.font.getGlyphIDs(line))
-              .reduce((sum, value) => sum + value, 0) ?? 0
-          );
-          
-          return Math.max(...lineWidths, 0);
-        },
-      ),
+              .reduce((sum, value) => sum + value, 0) ?? 0,
+        );
+
+        return Math.max(...lineWidths, 0);
+      }),
     );
 
     return {

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -146,8 +146,8 @@ export type AxisProps<
     | AxisLabelPosition
     | { x: AxisLabelPosition; y: AxisLabelPosition };
   axisSide?: { x: XAxisSide; y: YAxisSide };
-  formatXLabel?: (label: InputFields<RawData>[XK]) => string;
-  formatYLabel?: (label: RawData[YK]) => string;
+  formatXLabel?: (label: InputFields<RawData>[XK]) => string | string[];
+  formatYLabel?: (label: RawData[YK]) => string | string[];
   domain?: YAxisDomain;
   isNumericalData?: boolean;
   ix?: InputFields<RawData>[XK][];
@@ -176,8 +176,8 @@ export type OptionalAxisProps<
 > = {
   tickValues?: number[] | { x: number[]; y: number[] };
   font?: SkFont | null;
-  formatXLabel?: (label: InputFields<RawData>[XK]) => string;
-  formatYLabel?: (label: RawData[YK]) => string;
+  formatXLabel?: (label: InputFields<RawData>[XK]) => string | string[];
+  formatYLabel?: (label: RawData[YK]) => string | string[];
 };
 
 type DashPathEffectProps = React.ComponentProps<typeof DashPathEffect>;
@@ -189,7 +189,7 @@ export type XAxisInputProps<
 > = {
   axisSide?: XAxisSide;
   font?: SkFont | null;
-  formatXLabel?: (label: InputFields<RawData>[XK]) => string;
+  formatXLabel?: (label: InputFields<RawData>[XK]) => string | string[];
   labelColor?: string;
   labelOffset?: number;
   labelPosition?: AxisLabelPosition;
@@ -201,6 +201,11 @@ export type XAxisInputProps<
   yAxisSide?: YAxisSide;
   linePathEffect?: DashPathEffectComponent;
   enableRescaling?: boolean;
+  multiline?: {
+    enabled?: boolean;
+    maxLines?: number;
+    lineHeight?: number;
+  };
 };
 
 export type XAxisPropsWithDefaults<
@@ -209,7 +214,12 @@ export type XAxisPropsWithDefaults<
 > = Required<
   Omit<
     XAxisInputProps<RawData, XK>,
-    "font" | "tickValues" | "linePathEffect" | "enableRescaling" | "labelRotate"
+    | "font"
+    | "tickValues"
+    | "linePathEffect"
+    | "enableRescaling"
+    | "labelRotate"
+    | "multiline"
   >
 > &
   Partial<
@@ -220,6 +230,7 @@ export type XAxisPropsWithDefaults<
       | "linePathEffect"
       | "enableRescaling"
       | "labelRotate"
+      | "multiline"
     >
   >;
 
@@ -241,7 +252,7 @@ export type YAxisInputProps<
 > = {
   axisSide?: YAxisSide;
   font?: SkFont | null;
-  formatYLabel?: (label: RawData[YK]) => string;
+  formatYLabel?: (label: RawData[YK]) => string | string[];
   labelColor?: string;
   labelOffset?: number;
   labelPosition?: AxisLabelPosition;
@@ -253,6 +264,11 @@ export type YAxisInputProps<
   domain?: YAxisDomain;
   linePathEffect?: DashPathEffectComponent;
   enableRescaling?: boolean;
+  multiline?: {
+    enabled?: boolean;
+    maxLines?: number;
+    lineHeight?: number;
+  };
 };
 
 export type YAxisPropsWithDefaults<
@@ -261,13 +277,13 @@ export type YAxisPropsWithDefaults<
 > = Required<
   Omit<
     YAxisInputProps<RawData, YK>,
-    "font" | "tickValues" | "linePathEffect" | "enableRescaling"
+    "font" | "tickValues" | "linePathEffect" | "enableRescaling" | "multiline"
   >
 > &
   Partial<
     Pick<
       YAxisInputProps<RawData, YK>,
-      "font" | "tickValues" | "linePathEffect" | "enableRescaling"
+      "font" | "tickValues" | "linePathEffect" | "enableRescaling" | "multiline"
     >
   >;
 


### PR DESCRIPTION

### Description
- Add multiline axis label support for both X and Y axes using newline characters and string arrays
- Update CartesianAxis component to handle multiline labels with proper width calculation per line
- Implement dynamic label positioning that accounts for individual line widths in multiline scenarios
- Add new example route demonstrating multiline axis labels with months and performance metrics
- Update type definitions to support string array format for axis labels
- Improve label offset and spacing calculations for better visual alignment of multiline text
- Add changeset entry documenting the new multiline axis label feature

Fixes # (issue)
- Resolved multiline issue. 

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have run `yarn run check:code` and all checks pass
- [x] I have created a changeset for new features, patches, or major changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
