### PR TITLE
fix: correct tooltip coordinate mapping when chart is zoomed + fix pa…

### DIFF
--- a/.changeset/fix-gesture-dead-zones-zoom-tooltip.md
+++ b/.changeset/fix-gesture-dead-zones-zoom-tooltip.md
@@ -1,0 +1,20 @@
+---
+"victory-native": patch
+---
+
+Fix pan/zoom dead zones and incorrect tooltip position when chart is zoomed
+
+**GestureHandler dead zones (relates to #515):** The gesture handler view was being
+translated and scaled in sync with the chart's transform matrix. This caused its
+hit-testable area to drift so that touches starting outside the original chart
+viewport (e.g. after panning the chart) were silently ignored. The handler now
+fills its parent container unconditionally; CartesianChart's `handleTouch` already
+compensates for the current pan offset, so tooltip accuracy is unaffected.
+
+**Tooltip snaps to wrong data point when zoomed:** `handleTouch` was computing the
+canvas-space x coordinate as `touch.absoluteX - translateX`. This correctly cancels
+the pan offset but does not account for the zoom scale, so at `scaleX > 1` the
+computed position overshot into the far end of the data range. The fix switches to
+view-relative `touch.x` / `touch.y` (which already accounts for the container
+offset) and divides by the current scale to map back to original canvas coordinates:
+`(touch.x - translateX) / scaleX`.

--- a/example/app/pie-and-donut-charts.tsx
+++ b/example/app/pie-and-donut-charts.tsx
@@ -7,8 +7,20 @@ import {
   Rect,
   vec,
 } from "@shopify/react-native-skia";
-import { Pie, PolarChart } from "victory-native";
+import {
+  Pie,
+  PolarChart,
+  setScale,
+  setTranslate,
+  useChartTransformState,
+} from "victory-native";
+import {
+  useAnimatedReaction,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
 import { InfoCard } from "example/components/InfoCard";
+import { Button } from "example/components/Button";
 import { Text } from "example/components/Text";
 import { appColors } from "../consts/colors";
 import { descriptionForRoute } from "../consts/routes";
@@ -319,6 +331,74 @@ const HalfDonutChart = () => {
   );
 };
 
+const DonutChartWithPanZoom = () => {
+  const [data] = useState(DATA(6));
+  const { state } = useChartTransformState();
+
+  // Mirror scale + translate into individual shared values so we can animate
+  // them independently (e.g. spring back to identity on reset).
+  const k = useSharedValue(1);
+  const tx = useSharedValue(0);
+  const ty = useSharedValue(0);
+
+  useAnimatedReaction(
+    () => ({ k: k.value, tx: tx.value, ty: ty.value }),
+    ({ k, tx, ty }) => {
+      const m = setTranslate(state.matrix.value, tx, ty);
+      state.matrix.value = setScale(m, k);
+    },
+  );
+
+  const resetTransform = () => {
+    k.value = withTiming(1);
+    tx.value = withTiming(0);
+    ty.value = withTiming(0);
+  };
+
+  return (
+    <View style={{ flex: 1 }}>
+      <PolarChart
+        data={data}
+        labelKey={"label"}
+        valueKey={"value"}
+        colorKey={"color"}
+        transformState={state}
+      >
+        <Pie.Chart innerRadius={"50%"}>
+          {({ slice }) => {
+            const { startX, startY, endX, endY } = calculateGradientPoints(
+              slice.radius,
+              slice.startAngle,
+              slice.endAngle,
+              slice.center.x,
+              slice.center.y,
+            );
+            return (
+              <>
+                <Pie.Slice>
+                  <LinearGradient
+                    start={vec(startX, startY)}
+                    end={vec(endX, endY)}
+                    colors={[slice.color, `${slice.color}50`]}
+                    positions={[0, 1]}
+                  />
+                </Pie.Slice>
+                <Pie.SliceAngularInset
+                  angularInset={{
+                    angularStrokeWidth: 4,
+                    angularStrokeColor: "white",
+                  }}
+                />
+              </>
+            );
+          }}
+        </Pie.Chart>
+      </PolarChart>
+      <Button title="Reset zoom" onPress={resetTransform} />
+    </View>
+  );
+};
+
 export default function PieAndDonutCharts(props: { segment: string }) {
   const description = descriptionForRoute(props.segment);
 
@@ -360,6 +440,10 @@ export default function PieAndDonutCharts(props: { segment: string }) {
         <View style={styles.chartContainer}>
           <Text style={styles.title}>Half Donut Chart</Text>
           <HalfDonutChart />
+        </View>
+        <View style={styles.chartContainer}>
+          <Text style={styles.title}>Donut Chart with Pan & Zoom</Text>
+          <DonutChartWithPanZoom />
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/lib/src/cartesian/CartesianChart.tsx
+++ b/lib/src/cartesian/CartesianChart.tsx
@@ -445,14 +445,21 @@ function CartesianChartContent<
 
           v.isActive.value = true;
 
-          // [3] and [7] are the X and Y translation components of the 4x4 transformation matrix, respectively.
+          // Matrix layout (row-major 4x4): [0]=scaleX [3]=translateX [5]=scaleY [7]=translateY.
+          // Use view-relative touch.x/y instead of absoluteX/Y so that the
+          // chart container's screen offset is already factored out, then
+          // divide by the current scale to map back to original canvas coords.
+          // Without the scale division, the tooltip snaps to the wrong data
+          // point whenever the chart is zoomed in (scaleX > 1).
           const scrolledX = transformState?.matrix.value?.[3] || 0;
           const scrolledY = transformState?.matrix.value?.[7] || 0;
+          const scaleX = transformState?.matrix.value?.[0] || 1;
+          const scaleY = transformState?.matrix.value?.[5] || 1;
 
           handleTouch(
             v,
-            touch.absoluteX - scrolledX,
-            touch.absoluteY - scrolledY,
+            (touch.x - scrolledX) / scaleX,
+            (touch.y - scrolledY) / scaleY,
           );
         } else {
           gestureState.value.bootstrap.push([v, touch]);
@@ -475,11 +482,13 @@ function CartesianChartContent<
 
         const scrolledX = transformState?.matrix.value?.[3] || 0;
         const scrolledY = transformState?.matrix.value?.[7] || 0;
+        const scaleX = transformState?.matrix.value?.[0] || 1;
+        const scaleY = transformState?.matrix.value?.[5] || 1;
 
         handleTouch(
           v,
-          touch.absoluteX - scrolledX,
-          touch.absoluteY - scrolledY,
+          (touch.x - scrolledX) / scaleX,
+          (touch.y - scrolledY) / scaleY,
         );
       }
     })
@@ -508,11 +517,13 @@ function CartesianChartContent<
 
         const scrolledX = transformState?.matrix.value?.[3] || 0;
         const scrolledY = transformState?.matrix.value?.[7] || 0;
+        const scaleX = transformState?.matrix.value?.[0] || 1;
+        const scaleY = transformState?.matrix.value?.[5] || 1;
 
         handleTouch(
           v,
-          touch.absoluteX - scrolledX,
-          touch.absoluteY - scrolledY,
+          (touch.x - scrolledX) / scaleX,
+          (touch.y - scrolledY) / scaleY,
         );
       }
     })
@@ -752,19 +763,7 @@ function CartesianChartContent<
     <GestureHandlerRootView>
       <View style={{ flex: 1, overflow: "hidden" }} onLayout={onLayout}>
         {body}
-        <GestureHandler
-          config={gestureHandlerConfig}
-          gesture={composed}
-          transformState={transformState}
-          dimensions={{
-            x: Math.min(xScale.range()[0]!, 0),
-            y: Math.min(primaryYScale.range()[0]!, 0),
-            width: xScale.range()[1]! - Math.min(xScale.range()[0]!, 0),
-            height:
-              primaryYScale.range()[1]! -
-              Math.min(primaryYScale.range()[0]!, 0),
-          }}
-        />
+        <GestureHandler config={gestureHandlerConfig} gesture={composed} />
       </View>
     </GestureHandlerRootView>
   );

--- a/lib/src/polar/PolarChart.tsx
+++ b/lib/src/polar/PolarChart.tsx
@@ -70,10 +70,7 @@ const PolarChartBase = (
             <Group matrix={transformState?.matrix}>{children}</Group>
           </Bridge>
         </Canvas>
-        <GestureHandler
-          gesture={composed}
-          dimensions={{ x: 0, y: 0, width: width, height: height }}
-        />
+        <GestureHandler gesture={composed} />
       </GestureHandlerRootView>
     </View>
   );

--- a/lib/src/shared/GestureHandler.tsx
+++ b/lib/src/shared/GestureHandler.tsx
@@ -3,74 +3,39 @@ import {
   GestureDetector,
   type GestureType,
 } from "react-native-gesture-handler";
-import {
-  // convertToAffineMatrix,
-  // convertToColumnMajor,
-  // type Matrix4,
-  type SkRect,
-} from "@shopify/react-native-skia";
 import Animated, { useAnimatedStyle } from "react-native-reanimated";
-import {
-  /*Platform, type TransformsStyle,*/ type ViewStyle,
-} from "react-native";
 import * as React from "react";
-import { type ChartTransformState } from "../cartesian/hooks/useChartTransformState";
-import { getTransformComponents /*identity4*/ } from "../utils/transform";
 import type { GestureHandlerConfig } from "../types";
 
 type GestureHandlerProps = {
   gesture: ComposedGesture | GestureType;
-  dimensions: SkRect;
-  transformState?: ChartTransformState;
   debug?: boolean;
   config?: GestureHandlerConfig;
 };
 export const GestureHandler = ({
   gesture,
-  dimensions,
-  transformState,
   debug = false,
   config,
 }: GestureHandlerProps) => {
-  const { x, y, width, height } = dimensions;
   const style = useAnimatedStyle(() => {
-    // let m4: Matrix4 = identity4;
-    let transforms: ViewStyle["transform"] = [];
-    if (transformState?.matrix.value) {
-      const decomposed = getTransformComponents(transformState.matrix.value);
-      transforms = [
-        { translateX: decomposed.translateX },
-        { translateY: decomposed.translateY },
-        { scaleX: decomposed.scaleX },
-        { scaleY: decomposed.scaleY },
-      ];
-      // m4 = convertToColumnMajor(transformState.matrix.value);
-    }
+    // Keep the gesture handler fixed over the entire parent container rather
+    // than moving it in sync with the chart's transform. When the handler
+    // followed the transform, panning or zooming the chart created dead zones:
+    // the hit-testable area drifted away from the visible canvas, so touches
+    // starting outside the *original* chart bounds were silently dropped.
+    //
+    // Filling the parent is safe because CartesianChart's handleTouch already
+    // compensates for the current pan/zoom offset when mapping a touch position
+    // back to a data point — the gesture handler itself does not need to move.
+    //
+    // Related issue: https://github.com/FormidableLabs/victory-native-xl/issues/515
     return {
       position: "absolute",
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
       backgroundColor: debug ? "rgba(100, 200, 300, 0.4)" : "transparent",
-      // x,
-      // y,
-      left: x,
-      top: y,
-      width,
-      height,
-      transform: [
-        { translateX: -width / 2 - x },
-        { translateY: -height / 2 },
-        // Running into issues using 'matrix' transforms when enabling the new arch:
-        // https://github.com/facebook/react-native/issues/47467
-        // {
-        //   matrix: m4
-        //     ? Platform.OS === "web"
-        //       ? convertToAffineMatrix(m4)
-        //       : undefined
-        //     : undefined,
-        // },
-        ...transforms,
-        { translateX: x + width / 2 },
-        { translateY: height / 2 },
-      ],
     };
   });
   return (

--- a/lib/src/shared/GestureHandler.tsx
+++ b/lib/src/shared/GestureHandler.tsx
@@ -35,7 +35,7 @@ export const GestureHandler = ({
       left: 0,
       right: 0,
       bottom: 0,
-      backgroundColor: debug ? "rgba(100, 200, 300, 0.4)" : "transparent",
+      backgroundColor: debug ? "rgba(100, 200, 255, 0.4)" : "transparent",
     };
   });
   return (


### PR DESCRIPTION
# Fix: gesture dead zones + wrong tooltip position when chart is zoomed

Fixes #515 (partially) and a related coordinate mapping bug.

---

### Description

This PR fixes two separate but connected bugs that both surface when `transformState` (pan/zoom) is active alongside `chartPressState`.

**Bug 1; Dead zones after panning or zooming**

`GestureHandler` was applying the chart's transform matrix to its own React Native view style, so the gesture hit area physically moved along with the chart content. After panning far enough, the hit area drifted off-screen or into a region the user couldn't reach, making pan/zoom gestures silently fail. The fix is straightforward: the handler fills its entire parent container instead of following the transform. `CartesianChart`'s `handleTouch` already reads the current pan offset out of the matrix and compensates, so tooltip accuracy is not affected by this change.

**Bug 2; Tooltip snaps to the wrong data point when zoomed**

`handleTouch` was computing the canvas-space touch position as:

```
touch.absoluteX - translateX
```

Subtracting the translate cancels the pan, but zoom scale is never factored out. At `scaleX = 2`, a finger in the centre of the screen produces a value roughly twice the correct canvas coordinate, which consistently maps to a data point near the far end of the range; the chart appears to "jump to max X" every time you lift and re-place your finger.

The fix uses view-relative `touch.x` / `touch.y` (which already accounts for where the container sits on screen) and divides by the current scale:

```
(touch.x - translateX) / scaleX
```

This works for all combinations of pan and zoom. When no transform is applied (`scaleX = 1`, `translateX = 0`) the formula reduces to `touch.x`, which is equivalent to the old behaviour.

The two fixes are coupled: switching to `touch.x` is only correct once `GestureHandler` is stationary (Bug 1 fix), because `touch.x` is relative to the handler view itself.

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

---

### How Has This Been Tested?

Tested manually on android with a `CartesianChart` using `chartPressState` and `transformState` together:

- Pan the chart ~50% to the right, then drag a single finger across it -> the tooltip now follows the finger the full width of the canvas with no dead zones.
- Pinch to zoom 2× in, then tap/drag to show the tooltip -> it tracks the correct data point instead of jumping to the end of the series.
- With no transform applied (default state) the tooltip behaviour is unchanged.

---

### Checklist

- [x] I have included a changeset
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `yarn run check:code` and all checks pass
- [x] My changes generate no new warnings
