### PR TITLE
Fix chartPressConfig pan Y offset wiring

### DIFF
--- a/.changeset/fix-chart-press-pan-y-offsets.md
+++ b/.changeset/fix-chart-press-pan-y-offsets.md
@@ -1,0 +1,5 @@
+---
+"victory-native": patch
+---
+
+Fix `chartPressConfig.pan` Y offset options being applied to X gesture methods.

--- a/lib/src/cartesian/CartesianChart.tsx
+++ b/lib/src/cartesian/CartesianChart.tsx
@@ -57,6 +57,7 @@ import { ChartWrapper } from "../shared/ChartWrapper";
 import { useChartCanvasSize } from "../shared/useChartCanvasSize";
 import { boundsToClip } from "../utils/boundsToClip";
 import { normalizeYAxisTicks } from "../utils/normalizeYAxisTicks";
+import { applyChartPressPanConfig } from "./utils/applyChartPressPanConfig";
 import { createFallbackChartState } from "./utils/createFallbackChartState";
 import { getCartesianTouchCoordinates } from "./utils/getCartesianTouchCoordinates";
 
@@ -546,31 +547,11 @@ function CartesianChartContent<
       }
     });
 
-  if (!chartPressConfig?.pan) {
-    /**
-     * Activate after a long press, which helps with preventing all touch hijacking.
-     * This is important if this chart is inside of some sort of scrollable container.
-     */
-    panGesture.activateAfterLongPress(gestureLongPressDelay);
-  }
-
-  if (chartPressConfig?.pan?.activateAfterLongPress) {
-    panGesture.activateAfterLongPress(
-      chartPressConfig.pan?.activateAfterLongPress,
-    );
-  }
-  if (chartPressConfig?.pan?.activeOffsetX) {
-    panGesture.activeOffsetX(chartPressConfig.pan.activeOffsetX);
-  }
-  if (chartPressConfig?.pan?.activeOffsetY) {
-    panGesture.activeOffsetX(chartPressConfig.pan.activeOffsetY);
-  }
-  if (chartPressConfig?.pan?.failOffsetX) {
-    panGesture.failOffsetX(chartPressConfig.pan.failOffsetX);
-  }
-  if (chartPressConfig?.pan?.failOffsetY) {
-    panGesture.failOffsetX(chartPressConfig.pan.failOffsetY);
-  }
+  applyChartPressPanConfig({
+    panGesture,
+    panConfig: chartPressConfig?.pan,
+    gestureLongPressDelay,
+  });
 
   /**
    * Allow end-user to request "raw-ish" data for a given yKey.

--- a/lib/src/cartesian/utils/applyChartPressPanConfig.test.ts
+++ b/lib/src/cartesian/utils/applyChartPressPanConfig.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import { applyChartPressPanConfig } from "./applyChartPressPanConfig";
+
+const createPanGesture = () => ({
+  activateAfterLongPress: vi.fn(),
+  activeOffsetX: vi.fn(),
+  activeOffsetY: vi.fn(),
+  failOffsetX: vi.fn(),
+  failOffsetY: vi.fn(),
+});
+
+describe("applyChartPressPanConfig", () => {
+  it("uses the default long-press delay when no pan config is provided", () => {
+    const panGesture = createPanGesture();
+
+    applyChartPressPanConfig({
+      panGesture,
+      gestureLongPressDelay: 150,
+    });
+
+    expect(panGesture.activateAfterLongPress).toHaveBeenCalledWith(150);
+    expect(panGesture.activeOffsetX).not.toHaveBeenCalled();
+    expect(panGesture.activeOffsetY).not.toHaveBeenCalled();
+    expect(panGesture.failOffsetX).not.toHaveBeenCalled();
+    expect(panGesture.failOffsetY).not.toHaveBeenCalled();
+  });
+
+  it("wires each chartPressConfig pan option to the matching gesture method", () => {
+    const panGesture = createPanGesture();
+
+    applyChartPressPanConfig({
+      panGesture,
+      gestureLongPressDelay: 150,
+      panConfig: {
+        activateAfterLongPress: 75,
+        activeOffsetX: [-20, 20],
+        activeOffsetY: [-8, 8],
+        failOffsetX: [-60, 60],
+        failOffsetY: [-12, 12],
+      },
+    });
+
+    expect(panGesture.activateAfterLongPress).toHaveBeenCalledWith(75);
+    expect(panGesture.activeOffsetX).toHaveBeenCalledWith([-20, 20]);
+    expect(panGesture.activeOffsetY).toHaveBeenCalledWith([-8, 8]);
+    expect(panGesture.failOffsetX).toHaveBeenCalledWith([-60, 60]);
+    expect(panGesture.failOffsetY).toHaveBeenCalledWith([-12, 12]);
+  });
+});

--- a/lib/src/cartesian/utils/applyChartPressPanConfig.ts
+++ b/lib/src/cartesian/utils/applyChartPressPanConfig.ts
@@ -1,0 +1,50 @@
+import type { ChartPressPanConfig } from "../../types";
+
+type ChartPressPanGesture = {
+  activateAfterLongPress: (
+    delay: NonNullable<ChartPressPanConfig["activateAfterLongPress"]>,
+  ) => void;
+  activeOffsetX: (
+    offset: NonNullable<ChartPressPanConfig["activeOffsetX"]>,
+  ) => void;
+  activeOffsetY: (
+    offset: NonNullable<ChartPressPanConfig["activeOffsetY"]>,
+  ) => void;
+  failOffsetX: (
+    offset: NonNullable<ChartPressPanConfig["failOffsetX"]>,
+  ) => void;
+  failOffsetY: (
+    offset: NonNullable<ChartPressPanConfig["failOffsetY"]>,
+  ) => void;
+};
+
+export const applyChartPressPanConfig = ({
+  panGesture,
+  panConfig,
+  gestureLongPressDelay,
+}: {
+  panGesture: ChartPressPanGesture;
+  panConfig?: ChartPressPanConfig;
+  gestureLongPressDelay: number;
+}) => {
+  if (!panConfig) {
+    panGesture.activateAfterLongPress(gestureLongPressDelay);
+    return;
+  }
+
+  if (panConfig.activateAfterLongPress) {
+    panGesture.activateAfterLongPress(panConfig.activateAfterLongPress);
+  }
+  if (panConfig.activeOffsetX) {
+    panGesture.activeOffsetX(panConfig.activeOffsetX);
+  }
+  if (panConfig.activeOffsetY) {
+    panGesture.activeOffsetY(panConfig.activeOffsetY);
+  }
+  if (panConfig.failOffsetX) {
+    panGesture.failOffsetX(panConfig.failOffsetX);
+  }
+  if (panConfig.failOffsetY) {
+    panGesture.failOffsetY(panConfig.failOffsetY);
+  }
+};


### PR DESCRIPTION
## Summary
- extract chart press pan gesture config into a small tested helper
- route activeOffsetY to activeOffsetY and failOffsetY to failOffsetY
- add a patch changeset

## Verification
- node ../node_modules/vitest/vitest.mjs run src/cartesian/utils/applyChartPressPanConfig.test.ts
- node ../node_modules/vitest/vitest.mjs run
- node ./node_modules/typescript/bin/tsc --noEmit
- node ./node_modules/eslint/bin/eslint.js --ext .js,.ts,.tsx example lib

Refs #647. This fixes the Y-offset wiring typo mentioned there, but does not implement simultaneous parent ScrollView gestures.