### PR TITLE
Polish headless explicit size handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ example/ios/*
 npm-debug.*
 yarn-debug.*
 yarn-error.*
+lib/test/headless/**/*.diff.png
 
 # macOS
 .DS_Store

--- a/lib/src/shared/ChartLayoutModeProps.test.ts
+++ b/lib/src/shared/ChartLayoutModeProps.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { type ChartLayoutModeProps } from "./ChartLayoutModeProps";
+
+const explicitSize = { width: 100, height: 100 };
+const dynamicHeadless: boolean = true;
+
+const validLayoutModeProps: ChartLayoutModeProps[] = [
+  {},
+  { headless: false },
+  { explicitSize },
+  { explicitSize, headless: false },
+  { explicitSize, headless: true },
+  { explicitSize, headless: dynamicHeadless },
+];
+
+// @ts-expect-error `headless: true` requires `explicitSize`.
+const invalidHeadlessTrueWithoutExplicitSize: ChartLayoutModeProps = {
+  headless: true,
+};
+
+// @ts-expect-error dynamic `headless` may be true and requires `explicitSize`.
+const invalidBooleanHeadlessWithoutExplicitSize: ChartLayoutModeProps = {
+  headless: dynamicHeadless,
+};
+
+describe("ChartLayoutModeProps", () => {
+  it("allows dynamic headless values when explicitSize is set", () => {
+    expect(validLayoutModeProps).toHaveLength(6);
+    expect(invalidHeadlessTrueWithoutExplicitSize).toEqual({ headless: true });
+    expect(invalidBooleanHeadlessWithoutExplicitSize).toEqual({
+      headless: dynamicHeadless,
+    });
+  });
+});

--- a/lib/src/shared/ChartLayoutModeProps.ts
+++ b/lib/src/shared/ChartLayoutModeProps.ts
@@ -16,5 +16,5 @@ export type ChartLayoutModeProps =
     }
   | {
       explicitSize: ChartExplicitSize;
-      headless: true;
+      headless?: boolean;
     };

--- a/lib/src/shared/chartCanvasSizeUtils.ts
+++ b/lib/src/shared/chartCanvasSizeUtils.ts
@@ -1,14 +1,27 @@
 import { type ChartExplicitSize } from "./ChartExplicitSize";
 
 export type ChartCanvasSize = ChartExplicitSize;
+export type ChartCanvasSizeState = {
+  size: ChartCanvasSize;
+  hasMeasuredLayoutSize: boolean;
+};
 
 export function getInitialChartCanvasSizeState(
   explicitSize?: ChartExplicitSize,
-) {
+): ChartCanvasSizeState {
   return {
     size: explicitSize ?? { width: 0, height: 0 },
     hasMeasuredLayoutSize: Boolean(explicitSize),
   };
+}
+
+export function resolveChartCanvasSizeState(
+  layoutSizeState: ChartCanvasSizeState,
+  explicitSize?: ChartExplicitSize,
+): ChartCanvasSizeState {
+  return explicitSize
+    ? getInitialChartCanvasSizeState(explicitSize)
+    : layoutSizeState;
 }
 
 export function isChartHeadless(
@@ -16,6 +29,13 @@ export function isChartHeadless(
   explicitSize?: ChartExplicitSize,
 ) {
   return Boolean(headless && explicitSize);
+}
+
+export function shouldWarnMissingHeadlessExplicitSize(
+  headless?: boolean,
+  explicitSize?: ChartExplicitSize,
+) {
+  return Boolean(headless && !explicitSize);
 }
 
 export function applyChartLayoutChange(

--- a/lib/src/shared/useChartCanvasSize.test.ts
+++ b/lib/src/shared/useChartCanvasSize.test.ts
@@ -3,6 +3,8 @@ import {
   applyChartLayoutChange,
   getInitialChartCanvasSizeState,
   isChartHeadless,
+  resolveChartCanvasSizeState,
+  shouldWarnMissingHeadlessExplicitSize,
 } from "./chartCanvasSizeUtils";
 
 describe("getInitialChartCanvasSizeState", () => {
@@ -29,6 +31,55 @@ describe("isChartHeadless", () => {
     expect(isChartHeadless(true)).toBe(false);
     expect(isChartHeadless(false, { width: 100, height: 100 })).toBe(false);
     expect(isChartHeadless(true, { width: 100, height: 100 })).toBe(true);
+  });
+});
+
+describe("resolveChartCanvasSizeState", () => {
+  it("returns the measured layout state without explicitSize", () => {
+    expect(
+      resolveChartCanvasSizeState({
+        size: { width: 120, height: 80 },
+        hasMeasuredLayoutSize: true,
+      }),
+    ).toEqual({
+      size: { width: 120, height: 80 },
+      hasMeasuredLayoutSize: true,
+    });
+  });
+
+  it("uses explicitSize over the measured layout state", () => {
+    expect(
+      resolveChartCanvasSizeState(
+        {
+          size: { width: 120, height: 80 },
+          hasMeasuredLayoutSize: true,
+        },
+        { width: 320, height: 240 },
+      ),
+    ).toEqual({
+      size: { width: 320, height: 240 },
+      hasMeasuredLayoutSize: true,
+    });
+  });
+});
+
+describe("shouldWarnMissingHeadlessExplicitSize", () => {
+  it("warns only when headless is requested without explicitSize", () => {
+    expect(shouldWarnMissingHeadlessExplicitSize()).toBe(false);
+    expect(shouldWarnMissingHeadlessExplicitSize(false)).toBe(false);
+    expect(
+      shouldWarnMissingHeadlessExplicitSize(false, {
+        width: 100,
+        height: 100,
+      }),
+    ).toBe(false);
+    expect(
+      shouldWarnMissingHeadlessExplicitSize(true, {
+        width: 100,
+        height: 100,
+      }),
+    ).toBe(false);
+    expect(shouldWarnMissingHeadlessExplicitSize(true)).toBe(true);
   });
 });
 

--- a/lib/src/shared/useChartCanvasSize.ts
+++ b/lib/src/shared/useChartCanvasSize.ts
@@ -3,8 +3,9 @@ import { type LayoutChangeEvent } from "react-native";
 import { type ChartExplicitSize } from "./ChartExplicitSize";
 import {
   applyChartLayoutChange,
-  getInitialChartCanvasSizeState,
   isChartHeadless,
+  resolveChartCanvasSizeState,
+  shouldWarnMissingHeadlessExplicitSize,
 } from "./chartCanvasSizeUtils";
 
 /** Runtime layout args after prop destructuring (wider than {@link ChartLayoutModeProps}). */
@@ -18,19 +19,32 @@ export {
   applyChartLayoutChange,
   getInitialChartCanvasSizeState,
   isChartHeadless,
+  resolveChartCanvasSizeState,
+  shouldWarnMissingHeadlessExplicitSize,
 } from "./chartCanvasSizeUtils";
 
 export function useChartCanvasSize({
   explicitSize,
   headless,
 }: UseChartCanvasSizeProps) {
-  const [size, setSize] = React.useState(
-    () => getInitialChartCanvasSizeState(explicitSize).size,
-  );
-  const [hasMeasuredLayoutSize, setHasMeasuredLayoutSize] = React.useState(
-    () => getInitialChartCanvasSizeState(explicitSize).hasMeasuredLayoutSize,
-  );
+  const [size, setSize] = React.useState({ width: 0, height: 0 });
+  const [hasMeasuredLayoutSize, setHasMeasuredLayoutSize] =
+    React.useState(false);
   const isHeadless = isChartHeadless(headless, explicitSize);
+  const resolvedChartCanvasSizeState = resolveChartCanvasSizeState(
+    { size, hasMeasuredLayoutSize },
+    explicitSize,
+  );
+
+  React.useEffect(() => {
+    if (!shouldWarnMissingHeadlessExplicitSize(headless, explicitSize)) {
+      return;
+    }
+
+    console.warn(
+      "`headless` requires `explicitSize`. Falling back to layout-measured rendering.",
+    );
+  }, [headless, explicitSize]);
 
   const onLayout = React.useCallback(
     ({ nativeEvent: { layout } }: LayoutChangeEvent) => {
@@ -45,5 +59,9 @@ export function useChartCanvasSize({
     [explicitSize],
   );
 
-  return { size, hasMeasuredLayoutSize, onLayout, isHeadless };
+  return {
+    ...resolvedChartCanvasSizeState,
+    onLayout,
+    isHeadless,
+  };
 }


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/victory-native-xl/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

Follow-up polish for the headless rendering work:

- make `explicitSize` reactive after mount
- allow `headless={someBoolean}` when `explicitSize` is provided
- warn when `headless` is passed without `explicitSize`
- ignore generated headless golden diff images

Fixes # (issue)

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist: (Feel free to delete this section upon completion)

- [ ] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have run `yarn run check:code` and all checks pass
- [ ] I have created a changeset for new features, patches, or major changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
