### PR TITLE
Fix gesture overlay hit area alignment

### DIFF
--- a/.changeset/fix-gesture-overlay-hit-area.md
+++ b/.changeset/fix-gesture-overlay-hit-area.md
@@ -1,0 +1,5 @@
+---
+"victory-native": patch
+---
+
+Fix gesture overlay hit area by filling the chart container instead of applying plot-area dimensions and transform matrix offsets.

--- a/lib/src/cartesian/CartesianChart.tsx
+++ b/lib/src/cartesian/CartesianChart.tsx
@@ -729,18 +729,7 @@ function CartesianChartContent<
     }
 
     gestureOverlay = (
-      <GestureHandler
-        config={gestureHandlerConfig}
-        gesture={composed}
-        transformState={transformState}
-        dimensions={{
-          x: Math.min(xScale.range()[0]!, 0),
-          y: Math.min(primaryYScale.range()[0]!, 0),
-          width: xScale.range()[1]! - Math.min(xScale.range()[0]!, 0),
-          height:
-            primaryYScale.range()[1]! - Math.min(primaryYScale.range()[0]!, 0),
-        }}
-      />
+      <GestureHandler config={gestureHandlerConfig} gesture={composed} />
     );
   }
 

--- a/lib/src/polar/PolarChart.tsx
+++ b/lib/src/polar/PolarChart.tsx
@@ -50,7 +50,6 @@ const PolarChartBase = (
     isHeadless,
     explicitSize,
   } = props;
-  const { width, height } = canvasSize;
   const Bridge: ContextBridge = useContextBridge();
 
   let composed = Gesture.Race();
@@ -82,12 +81,7 @@ const PolarChartBase = (
         isHeadless ? undefined : (content) => <Bridge>{content}</Bridge>
       }
       gestureOverlay={
-        isHeadless ? undefined : (
-          <GestureHandler
-            gesture={composed}
-            dimensions={{ x: 0, y: 0, width, height }}
-          />
-        )
+        isHeadless ? undefined : <GestureHandler gesture={composed} />
       }
     />
   );

--- a/lib/src/shared/GestureHandler.tsx
+++ b/lib/src/shared/GestureHandler.tsx
@@ -3,74 +3,29 @@ import {
   GestureDetector,
   type GestureType,
 } from "react-native-gesture-handler";
-import {
-  // convertToAffineMatrix,
-  // convertToColumnMajor,
-  // type Matrix4,
-  type SkRect,
-} from "@shopify/react-native-skia";
+
 import Animated, { useAnimatedStyle } from "react-native-reanimated";
-import {
-  /*Platform, type TransformsStyle,*/ type ViewStyle,
-} from "react-native";
 import * as React from "react";
-import { type ChartTransformState } from "../cartesian/hooks/useChartTransformState";
-import { getTransformComponents /*identity4*/ } from "../utils/transform";
 import type { GestureHandlerConfig } from "../types";
 
 type GestureHandlerProps = {
   gesture: ComposedGesture | GestureType;
-  dimensions: SkRect;
-  transformState?: ChartTransformState;
   debug?: boolean;
   config?: GestureHandlerConfig;
 };
 export const GestureHandler = ({
   gesture,
-  dimensions,
-  transformState,
   debug = false,
   config,
 }: GestureHandlerProps) => {
-  const { x, y, width, height } = dimensions;
   const style = useAnimatedStyle(() => {
-    // let m4: Matrix4 = identity4;
-    let transforms: ViewStyle["transform"] = [];
-    if (transformState?.matrix.value) {
-      const decomposed = getTransformComponents(transformState.matrix.value);
-      transforms = [
-        { translateX: decomposed.translateX },
-        { translateY: decomposed.translateY },
-        { scaleX: decomposed.scaleX },
-        { scaleY: decomposed.scaleY },
-      ];
-      // m4 = convertToColumnMajor(transformState.matrix.value);
-    }
     return {
       position: "absolute",
-      backgroundColor: debug ? "rgba(100, 200, 300, 0.4)" : "transparent",
-      // x,
-      // y,
-      left: x,
-      top: y,
-      width,
-      height,
-      transform: [
-        { translateX: -width / 2 - x },
-        { translateY: -height / 2 },
-        // Running into issues using 'matrix' transforms when enabling the new arch:
-        // https://github.com/facebook/react-native/issues/47467
-        // {
-        //   matrix: m4
-        //     ? Platform.OS === "web"
-        //       ? convertToAffineMatrix(m4)
-        //       : undefined
-        //     : undefined,
-        // },
-        ...transforms,
-        { translateX: x + width / 2 },
-        { translateY: height / 2 },
-      ],
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      backgroundColor: debug ? "rgba(100, 200, 255, 0.4)" : "transparent",
     };
   });
   return (


### PR DESCRIPTION
Fill the chart container for gesture detection instead of sizing the overlay to plot-area dimensions with transform matrix offsets.

- Simplify `GestureHandler` to fill the chart container (`top/left/right/bottom: 0`) instead of sizing the overlay to plot-area scale ranges and applying transform matrix offsets.
- Remove unused `dimensions` and `transformState` props from `GestureHandler`, and update `CartesianChart` and `PolarChart` call sites accordingly.

The previous overlay positioning could misalign the gesture hit area relative to the visible chart, especially when chart transforms were applied. The overlay is already rendered as a sibling of the Skia `Canvas` inside `ChartWrapper`, so filling the container matches the intended touch target.


### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #515

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- [x] `yarn check:code` (lint, typecheck, unit tests, headless golden tests)
- [x] Verified chart press gestures work across the full chart area on device/simulator
- [x] Verified pan/zoom gestures still work on charts with transform state enabled
- [x] Verified polar chart gestures still work

### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a [changeset](https://github.com/FormidableLabs/victory-native-xl/blob/main/CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [x] I have run `yarn run check:code` and all checks pass
- [x] I have created a changeset for new features, patches, or major changes
- [x] Bug fix (non-breaking change which fixes an issue)
