### PR TITLE
Update `<PieSliceAngularInset />` to use `color`, `strokeWidth` and `style` params instead of `paint`

### DIFF
--- a/.changeset/cool-rivers-punch.md
+++ b/.changeset/cool-rivers-punch.md
@@ -1,0 +1,23 @@
+---
+"victory-native": major
+---
+
+Updated useSliceAngularInsetPath to return path only
+
+- This is a breacking change as the hook signature is different.
+- The change is made to fix a bug so that `useSliceAngularInsetPath`'s consumers provide their own styling to the `<Path />` component. For `<PieSliceAngularInset />` the supplied `paint` param is buggy (unknown root cause) and we do not need to pass `paint` param. Switched to `style`, `color` and `strokeWidth` as an alternative.
+- Existing consumers can update their code as follow:
+
+OLD
+
+```tsx
+const [path, insetPaint] = useSliceAngularInsetPath({ slice, angularInset });
+<Path path={path} paint={insetPaint} />;
+```
+
+NEW:
+
+```tsx
+const path = useSliceAngularInsetPath({ slice });
+<Path path={path} style="stroke" color={angularInset.angularStrokeColor} strokeWidth={angularInset.angularStrokeWidth} />;
+```

--- a/lib/src/pie/PieSliceAngularInset.tsx
+++ b/lib/src/pie/PieSliceAngularInset.tsx
@@ -6,36 +6,43 @@ import type { PathAnimationConfig } from "../hooks/useAnimatedPath";
 import { AnimatedPath } from "../cartesian/components/AnimatedPath";
 
 export type PieSliceAngularInsetData = {
-  angularStrokeWidth: number;
-  angularStrokeColor: Color;
+	angularStrokeWidth: number;
+	angularStrokeColor: Color;
 };
 
 type AdditionalPathProps = Partial<Omit<PathProps, "color" | "path">> & {
-  animate?: PathAnimationConfig;
+	animate?: PathAnimationConfig;
 };
 
 type PieSliceAngularInsetProps = {
-  angularInset: PieSliceAngularInsetData;
+	angularInset: PieSliceAngularInsetData;
 } & AdditionalPathProps;
 
 export const PieSliceAngularInset = (props: PieSliceAngularInsetProps) => {
-  const { angularInset, children, animate, ...rest } = props;
-  const { slice } = usePieSliceContext();
-  const [path, insetPaint] = useSliceAngularInsetPath({ slice, angularInset });
+	const { angularInset, children, animate, ...rest } = props;
+	const { slice } = usePieSliceContext();
+	const path = useSliceAngularInsetPath({ slice });
 
-  // If the path is empty, don't render anything
-  if (path.toSVGString() === "M0 0L0 0M0 0L0 0") {
-    return null;
-  }
+	// If the path is empty, don't render anything
+	if (path.toSVGString() === "M0 0L0 0M0 0L0 0") {
+		return null;
+	}
 
-  if (angularInset.angularStrokeWidth === 0) {
-    return null;
-  }
+	if (angularInset.angularStrokeWidth === 0) {
+		return null;
+	}
 
-  const Component = animate ? AnimatedPath : Path;
-  return (
-    <Component path={path} paint={insetPaint} animate={animate} {...rest}>
-      {children}
-    </Component>
-  );
+	const Component = animate ? AnimatedPath : Path;
+	return (
+		<Component
+			path={path}
+			style="stroke"
+			color={angularInset.angularStrokeColor}
+			strokeWidth={angularInset.angularStrokeWidth}
+			animate={animate}
+			{...rest}
+		>
+			{children}
+		</Component>
+	);
 };

--- a/lib/src/pie/PieSliceAngularInset.tsx
+++ b/lib/src/pie/PieSliceAngularInset.tsx
@@ -6,43 +6,43 @@ import type { PathAnimationConfig } from "../hooks/useAnimatedPath";
 import { AnimatedPath } from "../cartesian/components/AnimatedPath";
 
 export type PieSliceAngularInsetData = {
-	angularStrokeWidth: number;
-	angularStrokeColor: Color;
+  angularStrokeWidth: number;
+  angularStrokeColor: Color;
 };
 
 type AdditionalPathProps = Partial<Omit<PathProps, "color" | "path">> & {
-	animate?: PathAnimationConfig;
+  animate?: PathAnimationConfig;
 };
 
 type PieSliceAngularInsetProps = {
-	angularInset: PieSliceAngularInsetData;
+  angularInset: PieSliceAngularInsetData;
 } & AdditionalPathProps;
 
 export const PieSliceAngularInset = (props: PieSliceAngularInsetProps) => {
-	const { angularInset, children, animate, ...rest } = props;
-	const { slice } = usePieSliceContext();
-	const path = useSliceAngularInsetPath({ slice });
+  const { angularInset, children, animate, ...rest } = props;
+  const { slice } = usePieSliceContext();
+  const path = useSliceAngularInsetPath({ slice });
 
-	// If the path is empty, don't render anything
-	if (path.toSVGString() === "M0 0L0 0M0 0L0 0") {
-		return null;
-	}
+  // If the path is empty, don't render anything
+  if (path.toSVGString() === "M0 0L0 0M0 0L0 0") {
+    return null;
+  }
 
-	if (angularInset.angularStrokeWidth === 0) {
-		return null;
-	}
+  if (angularInset.angularStrokeWidth === 0) {
+    return null;
+  }
 
-	const Component = animate ? AnimatedPath : Path;
-	return (
-		<Component
-			path={path}
-			style="stroke"
-			color={angularInset.angularStrokeColor}
-			strokeWidth={angularInset.angularStrokeWidth}
-			animate={animate}
-			{...rest}
-		>
-			{children}
-		</Component>
-	);
+  const Component = animate ? AnimatedPath : Path;
+  return (
+    <Component
+      path={path}
+      style="stroke"
+      color={angularInset.angularStrokeColor}
+      strokeWidth={angularInset.angularStrokeWidth}
+      animate={animate}
+      {...rest}
+    >
+      {children}
+    </Component>
+  );
 };

--- a/lib/src/pie/hooks/useSliceAngularInsetPath.ts
+++ b/lib/src/pie/hooks/useSliceAngularInsetPath.ts
@@ -1,85 +1,77 @@
-import { Skia, PaintStyle } from "@shopify/react-native-skia";
+import { Skia } from "@shopify/react-native-skia";
 import { useMemo } from "react";
 import {
-  calculatePointOnCircumference,
-  degreesToRadians,
+	calculatePointOnCircumference,
+	degreesToRadians,
 } from "../utils/radians";
 import type { PieSliceData } from "../PieSlice";
-import type { PieSliceAngularInsetData } from "../PieSliceAngularInset";
 
 type SliceAngularInsetPathArgs = {
-  slice: PieSliceData;
-  angularInset: PieSliceAngularInsetData;
+	slice: PieSliceData;
 };
 export const useSliceAngularInsetPath = ({
-  angularInset,
-  slice,
+	slice,
 }: SliceAngularInsetPathArgs) => {
-  const [path, paint] = useMemo(() => {
-    const { radius, center, innerRadius } = slice;
+	const path = useMemo(() => {
+		const { radius, center, innerRadius } = slice;
 
-    const path = Skia.Path.Make();
+		const path = Skia.Path.Make();
 
-    // Convert angles to radians for calculations
-    const startRadians = degreesToRadians(slice.startAngle);
-    const endRadians = degreesToRadians(slice.endAngle);
+		// Convert angles to radians for calculations
+		const startRadians = degreesToRadians(slice.startAngle);
+		const endRadians = degreesToRadians(slice.endAngle);
 
-    if (innerRadius > 0) {
-      // Calculate start and end points on the inner circumference
-      const startPointInnerRadius = calculatePointOnCircumference(
-        center,
-        innerRadius,
-        startRadians,
-      );
-      const endPointInnerRadius = calculatePointOnCircumference(
-        center,
-        innerRadius,
-        endRadians,
-      );
-      //  Calculate start and end points on the outer circumference
-      const startPointOuterRadius = calculatePointOnCircumference(
-        center,
-        radius,
-        startRadians,
-      );
-      const endPointOuterRadius = calculatePointOnCircumference(
-        center,
-        radius,
-        endRadians,
-      );
+		if (innerRadius > 0) {
+			// Calculate start and end points on the inner circumference
+			const startPointInnerRadius = calculatePointOnCircumference(
+				center,
+				innerRadius,
+				startRadians,
+			);
+			const endPointInnerRadius = calculatePointOnCircumference(
+				center,
+				innerRadius,
+				endRadians,
+			);
+			//  Calculate start and end points on the outer circumference
+			const startPointOuterRadius = calculatePointOnCircumference(
+				center,
+				radius,
+				startRadians,
+			);
+			const endPointOuterRadius = calculatePointOnCircumference(
+				center,
+				radius,
+				endRadians,
+			);
 
-      // Move to center, draw line to start point, move to center, draw line to end point
-      path.moveTo(startPointInnerRadius.x, startPointInnerRadius.y);
-      path.lineTo(startPointOuterRadius.x, startPointOuterRadius.y);
-      path.moveTo(endPointInnerRadius.x, endPointInnerRadius.y);
-      path.lineTo(endPointOuterRadius.x, endPointOuterRadius.y);
-    } else {
-      // Calculate start and end points on the circumference
-      const startPoint = calculatePointOnCircumference(
-        center,
-        radius,
-        startRadians,
-      );
-      const endPoint = calculatePointOnCircumference(
-        center,
-        radius,
-        endRadians,
-      );
+			// Move to center, draw line to start point, move to center, draw line to end point
+			path.moveTo(startPointInnerRadius.x, startPointInnerRadius.y);
+			path.lineTo(startPointOuterRadius.x, startPointOuterRadius.y);
+			path.moveTo(endPointInnerRadius.x, endPointInnerRadius.y);
+			path.lineTo(endPointOuterRadius.x, endPointOuterRadius.y);
+		} else {
+			// Calculate start and end points on the circumference
+			const startPoint = calculatePointOnCircumference(
+				center,
+				radius,
+				startRadians,
+			);
+			const endPoint = calculatePointOnCircumference(
+				center,
+				radius,
+				endRadians,
+			);
 
-      // Move to center, draw line to start point, move to center, draw line to end point
-      path.moveTo(center.x, center.y);
-      path.lineTo(startPoint.x, startPoint.y);
-      path.moveTo(center.x, center.y);
-      path.lineTo(endPoint.x, endPoint.y);
-    }
+			// Move to center, draw line to start point, move to center, draw line to end point
+			path.moveTo(center.x, center.y);
+			path.lineTo(startPoint.x, startPoint.y);
+			path.moveTo(center.x, center.y);
+			path.lineTo(endPoint.x, endPoint.y);
+		}
 
-    // Create Paint for inset
-    const insetPaint = Skia.Paint();
-    insetPaint.setColor(Skia.Color(angularInset.angularStrokeColor));
-    insetPaint.setStyle(PaintStyle.Stroke);
-    insetPaint.setStrokeWidth(angularInset.angularStrokeWidth);
-    return [path, insetPaint] as const;
-  }, [slice, angularInset]);
+		return path;
+	}, [slice]);
 
-  return [path, paint] as const;
+	return path;
 };

--- a/lib/src/pie/hooks/useSliceAngularInsetPath.ts
+++ b/lib/src/pie/hooks/useSliceAngularInsetPath.ts
@@ -1,77 +1,77 @@
 import { Skia } from "@shopify/react-native-skia";
 import { useMemo } from "react";
 import {
-	calculatePointOnCircumference,
-	degreesToRadians,
+  calculatePointOnCircumference,
+  degreesToRadians,
 } from "../utils/radians";
 import type { PieSliceData } from "../PieSlice";
 
 type SliceAngularInsetPathArgs = {
-	slice: PieSliceData;
+  slice: PieSliceData;
 };
 export const useSliceAngularInsetPath = ({
-	slice,
+  slice,
 }: SliceAngularInsetPathArgs) => {
-	const path = useMemo(() => {
-		const { radius, center, innerRadius } = slice;
+  const path = useMemo(() => {
+    const { radius, center, innerRadius } = slice;
 
-		const path = Skia.Path.Make();
+    const path = Skia.Path.Make();
 
-		// Convert angles to radians for calculations
-		const startRadians = degreesToRadians(slice.startAngle);
-		const endRadians = degreesToRadians(slice.endAngle);
+    // Convert angles to radians for calculations
+    const startRadians = degreesToRadians(slice.startAngle);
+    const endRadians = degreesToRadians(slice.endAngle);
 
-		if (innerRadius > 0) {
-			// Calculate start and end points on the inner circumference
-			const startPointInnerRadius = calculatePointOnCircumference(
-				center,
-				innerRadius,
-				startRadians,
-			);
-			const endPointInnerRadius = calculatePointOnCircumference(
-				center,
-				innerRadius,
-				endRadians,
-			);
-			//  Calculate start and end points on the outer circumference
-			const startPointOuterRadius = calculatePointOnCircumference(
-				center,
-				radius,
-				startRadians,
-			);
-			const endPointOuterRadius = calculatePointOnCircumference(
-				center,
-				radius,
-				endRadians,
-			);
+    if (innerRadius > 0) {
+      // Calculate start and end points on the inner circumference
+      const startPointInnerRadius = calculatePointOnCircumference(
+        center,
+        innerRadius,
+        startRadians,
+      );
+      const endPointInnerRadius = calculatePointOnCircumference(
+        center,
+        innerRadius,
+        endRadians,
+      );
+      //  Calculate start and end points on the outer circumference
+      const startPointOuterRadius = calculatePointOnCircumference(
+        center,
+        radius,
+        startRadians,
+      );
+      const endPointOuterRadius = calculatePointOnCircumference(
+        center,
+        radius,
+        endRadians,
+      );
 
-			// Move to center, draw line to start point, move to center, draw line to end point
-			path.moveTo(startPointInnerRadius.x, startPointInnerRadius.y);
-			path.lineTo(startPointOuterRadius.x, startPointOuterRadius.y);
-			path.moveTo(endPointInnerRadius.x, endPointInnerRadius.y);
-			path.lineTo(endPointOuterRadius.x, endPointOuterRadius.y);
-		} else {
-			// Calculate start and end points on the circumference
-			const startPoint = calculatePointOnCircumference(
-				center,
-				radius,
-				startRadians,
-			);
-			const endPoint = calculatePointOnCircumference(
-				center,
-				radius,
-				endRadians,
-			);
+      // Move to center, draw line to start point, move to center, draw line to end point
+      path.moveTo(startPointInnerRadius.x, startPointInnerRadius.y);
+      path.lineTo(startPointOuterRadius.x, startPointOuterRadius.y);
+      path.moveTo(endPointInnerRadius.x, endPointInnerRadius.y);
+      path.lineTo(endPointOuterRadius.x, endPointOuterRadius.y);
+    } else {
+      // Calculate start and end points on the circumference
+      const startPoint = calculatePointOnCircumference(
+        center,
+        radius,
+        startRadians,
+      );
+      const endPoint = calculatePointOnCircumference(
+        center,
+        radius,
+        endRadians,
+      );
 
-			// Move to center, draw line to start point, move to center, draw line to end point
-			path.moveTo(center.x, center.y);
-			path.lineTo(startPoint.x, startPoint.y);
-			path.moveTo(center.x, center.y);
-			path.lineTo(endPoint.x, endPoint.y);
-		}
+      // Move to center, draw line to start point, move to center, draw line to end point
+      path.moveTo(center.x, center.y);
+      path.lineTo(startPoint.x, startPoint.y);
+      path.moveTo(center.x, center.y);
+      path.lineTo(endPoint.x, endPoint.y);
+    }
 
-		return path;
-	}, [slice]);
+    return path;
+  }, [slice]);
 
-	return path;
+  return path;
 };

--- a/website/docs/polar/pie/use-slice-angular-inset-path.md
+++ b/website/docs/polar/pie/use-slice-angular-inset-path.md
@@ -1,6 +1,6 @@
-# `useSliceAngularPath`
+# `useSliceAngularInsetPath`
 
-The `useSliceAngularPath` hook takes a `PieSliceData` as input, and returns an array of Skia `[SkPath, SkPaint]` objects that represent the path and the paint for that pie slice.
+The `useSliceAngularInsetPath` hook takes a `PieSliceData` as input, and returns a `SkPath` object that represents the path for that pie slice.
 
 :::info
 
@@ -11,15 +11,15 @@ The `useSliceAngularPath` hook takes a `PieSliceData` as input, and returns an a
 ## Example
 
 ```tsx
-import { Pie, useSliceAngularPath, type PieSliceData } from "victory-native";
+import { Pie, useSliceAngularInsetPath, type PieSliceData } from "victory-native";
 import { Path } from "@shopify/react-native-skia";
 import DATA from "./my-data";
 
 function MyCustomSliceAngularInset({ slice }: { slice: PieSliceData }) {
   // 👇 use the hook to generate a path and paint object.
-  const [path, insetPaint] = useSliceAngularInsetPath({ slice, angularInset });
+  const path = useSliceAngularInsetPath({ slice });
   /* 👇 experiment with any other customizations you want */
-  return <Path path={path} paint={insetPaint} {...rest} />;
+  return <Path path={path} style="stroke" strokeWidth={4} color="lightblue" {...rest} />;
 }
 
 export function MyChart() {
@@ -34,10 +34,10 @@ export function MyChart() {
 
 ## Arguments
 
-`useSliceAngularPath` has a function signature as follows:
+`useSliceAngularInsetPath` has a function signature as follows:
 
 ```ts
-useSliceAngularPath(slice: PieSliceData): [SkPath, SkPaint]
+useSliceAngularInsetPath(slice: PieSliceData): SkPath
 ```
 
 ### `slice`
@@ -46,6 +46,6 @@ The `slice` argument is a `PieSliceData` object used to generate the slices's pa
 
 ## Returns
 
-### [SkPath, SkPaint]
+### SkPath
 
-The `SkPath` path object to be used as the `path` argument of a Skia `<Path />` element. The `SkPaint` path object to be used as the `paint` argument of a Skia `<Path />` element.
+The `SkPath` path object to be used as the `path` argument of a Skia `<Path />` element.


### PR DESCRIPTION
### Description

In web, when rendering slices siblings and a paint e.g

```tsx
<Slice1 />
<Path paint={paint} />
<Slice2 />
```

Then the paint in `<Path />` seems to affect the descendants siblings (Slice2, etc.) and they do not render correctly. I tried to `<Group />` each slice with it's own paint but it didn't work either. The paint styles are somehow leaking. I don't think this is necessary a bug in this library. But it's something that can be avoided, since the paint constructed in `useSliceAngularInsetPath` only sets the `color`, `strokeWidth` and `style`, we can pass those as explicit params to `<Path />`.

Fixes # https://github.com/FormidableLabs/victory-native-xl/issues/652

#### Type of Change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How Has This Been Tested?

Tested the pie charts in the included example

**Before**
<img width="1728" height="658" alt="Screenshot 2026-06-01 at 4 30 15 PM" src="https://github.com/user-attachments/assets/e17a75d6-46d4-4ed0-96ce-97e2e63319f1" />

**After**
<img width="1728" height="603" alt="Screenshot 2026-06-01 at 4 36 17 PM" src="https://github.com/user-attachments/assets/47250a8f-15e3-4129-86de-61f6d915e12d" />

