### PR TITLE
feat: stacked bar refactor (horizontal/vertical)

### DIFF
--- a/.changeset/horizontal-stacked-bars.md
+++ b/.changeset/horizontal-stacked-bars.md
@@ -1,0 +1,5 @@
+---
+"victory-native": minor
+---
+
+Add `HorizontalStackedBar` and `useHorizontalStackedBarPaths` for stacked bar charts inside `CartesianChart orientation="horizontal"`.

--- a/.changeset/stacked-bar-option-fields.md
+++ b/.changeset/stacked-bar-option-fields.md
@@ -1,0 +1,5 @@
+---
+"victory-native": patch
+---
+
+Add orientation-neutral `isStart`, `isEnd`, `seriesIndex`, and `datumIndex` fields to stacked bar `barOptions` while preserving existing vertical field aliases.

--- a/example/app/horizontal-stacked-bar.tsx
+++ b/example/app/horizontal-stacked-bar.tsx
@@ -1,0 +1,616 @@
+import {
+  DashPathEffect,
+  LinearGradient,
+  useFont,
+  vec,
+} from "@shopify/react-native-skia";
+import * as React from "react";
+import { SafeAreaView, ScrollView, StyleSheet, View } from "react-native";
+import {
+  CartesianChart,
+  HorizontalStackedBar,
+  useChartPressState,
+} from "victory-native";
+import { useDarkMode } from "react-native-dark";
+import { runOnJS, useAnimatedReaction } from "react-native-reanimated";
+import inter from "../assets/inter-medium.ttf";
+import { appColors } from "../consts/colors";
+import { Button } from "../components/Button";
+import { InfoCard } from "../components/InfoCard";
+import { InputSlider } from "../components/InputSlider";
+import { Text } from "../components/Text";
+import { descriptionForRoute } from "../consts/routes";
+
+type ChannelDatum = {
+  category: string;
+  product: number;
+  services: number;
+  support: number;
+};
+
+type OptionalChannelDatum = {
+  category: string;
+  product?: number;
+  services?: number;
+  support?: number;
+};
+
+const SERIES_COLORS = ["#14b8a6", "#6366f1", "#f97316"];
+const SERIES_LABELS = ["Product", "Services", "Support"];
+
+const BASE_DATA: ChannelDatum[] = [
+  { category: "North", product: 72, services: 44, support: 28 },
+  { category: "West", product: 58, services: 62, support: 34 },
+  { category: "South", product: 41, services: 38, support: 46 },
+  { category: "East", product: 67, services: 52, support: 31 },
+];
+
+const MIXED_DATA: ChannelDatum[] = [
+  { category: "Plan", product: 58, services: -22, support: 34 },
+  { category: "Build", product: 74, services: 42, support: -18 },
+  { category: "Ship", product: 45, services: 63, support: 28 },
+  { category: "Support", product: -16, services: 36, support: 52 },
+];
+
+const TOUCHABLE_DATA: ChannelDatum[] = [
+  { category: "Alpha", product: 48, services: 36, support: 24 },
+  { category: "Beta", product: 34, services: -22, support: 38 },
+  { category: "Gamma", product: 52, services: 28, support: -16 },
+  { category: "Delta", product: -18, services: 44, support: 26 },
+];
+
+const CUSTOM_CHILDREN_DATA: ChannelDatum[] = [
+  { category: "Core", product: 62, services: 34, support: 20 },
+  { category: "Cloud", product: 48, services: 54, support: 28 },
+  { category: "Edge", product: 32, services: 26, support: 42 },
+];
+
+const NON_UNIFORM_DATA: OptionalChannelDatum[] = [
+  { category: "Full", product: 42, services: 36, support: 20 },
+  { category: "No product", services: 48, support: 26 },
+  { category: "Support only", support: 54 },
+  { category: "Zero support", product: 38, services: 22, support: 0 },
+  { category: "Mixed", product: 34, services: -18, support: 24 },
+];
+
+export default function HorizontalStackedBarPage(props: { segment: string }) {
+  const description = descriptionForRoute(props.segment);
+  const font = useFont(inter, 12);
+  const isDark = useDarkMode();
+  const [data, setData] = React.useState(MIXED_DATA);
+  const [innerPadding, setInnerPadding] = React.useState(0.4);
+  const [roundedCorner, setRoundedCorner] = React.useState(8);
+
+  const axisLabelColor = isDark ? appColors.text.dark : appColors.text.light;
+
+  return (
+    <SafeAreaView style={styles.safeView}>
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.content}
+        contentInsetAdjustmentBehavior="automatic"
+      >
+        <InfoCard>{description}</InfoCard>
+
+        <ChartSection
+          title="Interactive Mixed Stacks"
+          description="Positive and negative segments accumulate from the same zero baseline."
+        >
+          <View style={styles.largeChart}>
+            <HorizontalStackedChart
+              data={data}
+              font={font}
+              axisLabelColor={axisLabelColor}
+              innerPadding={innerPadding}
+              roundedCorner={roundedCorner}
+              domain={[-50, 170]}
+            />
+          </View>
+
+          <Legend />
+
+          <View style={styles.row}>
+            <Button
+              accessibilityLabel="Shuffle horizontal stacked bar data"
+              style={styles.rowButton}
+              onPress={() => setData((current) => shuffleData(current))}
+              title="Shuffle Data"
+            />
+            <Button
+              accessibilityLabel="Toggle mixed horizontal stacked bar values"
+              style={styles.rowButton}
+              onPress={() =>
+                setData((current) =>
+                  current === MIXED_DATA ? BASE_DATA : MIXED_DATA,
+                )
+              }
+              title="Toggle Mixed"
+            />
+          </View>
+
+          <InputSlider
+            label="Inner Padding"
+            maxValue={0.8}
+            minValue={0}
+            step={0.05}
+            value={innerPadding}
+            onChange={setInnerPadding}
+          />
+          <InputSlider
+            label="Value-End Corner Radius"
+            maxValue={18}
+            minValue={0}
+            step={1}
+            value={roundedCorner}
+            onChange={setRoundedCorner}
+          />
+        </ChartSection>
+
+        <ChartSection
+          title="Touchable Segments"
+          description="Press a segment to verify horizontal stacked segment lookup and selection styling."
+        >
+          <View style={styles.mediumChart}>
+            <TouchableSegmentsChart
+              font={font}
+              axisLabelColor={axisLabelColor}
+            />
+          </View>
+        </ChartSection>
+
+        <ChartSection
+          title="Custom Segment Children"
+          description="Segments can provide Skia children such as gradients through barOptions."
+        >
+          <View style={styles.mediumChart}>
+            <CustomChildrenChart font={font} axisLabelColor={axisLabelColor} />
+          </View>
+        </ChartSection>
+
+        <ChartSection
+          title="Missing And Zero Segments"
+          description="Missing values are skipped, zero values stay zero-width, and outer corners remain on visible stack ends."
+        >
+          <View style={styles.tallChart}>
+            <NonUniformChart font={font} axisLabelColor={axisLabelColor} />
+          </View>
+        </ChartSection>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function ChartSection({
+  title,
+  description,
+  children,
+}: React.PropsWithChildren<{ title: string; description: string }>) {
+  return (
+    <View style={styles.section}>
+      <View style={styles.sectionHeader}>
+        <Text selectable style={styles.sectionTitle}>
+          {title}
+        </Text>
+        <Text selectable style={styles.sectionDescription}>
+          {description}
+        </Text>
+      </View>
+      {children}
+    </View>
+  );
+}
+
+function HorizontalStackedChart({
+  data,
+  font,
+  axisLabelColor,
+  innerPadding,
+  roundedCorner,
+  domain,
+}: {
+  data: ChannelDatum[];
+  font: ReturnType<typeof useFont>;
+  axisLabelColor: string;
+  innerPadding: number;
+  roundedCorner: number;
+  domain: [number, number];
+}) {
+  return (
+    <CartesianChart
+      orientation="horizontal"
+      data={data}
+      xKey="category"
+      yKeys={["product", "services", "support"]}
+      domain={{ x: domain }}
+      domainPadding={{ top: 36, bottom: 36, left: 18, right: 24 }}
+      padding={5}
+      xAxis={{
+        font,
+        tickCount: 6,
+        labelColor: axisLabelColor,
+        linePathEffect: <DashPathEffect intervals={[4, 4]} />,
+        formatXLabel: (value) => `${value}`,
+      }}
+      yAxis={[
+        {
+          yKeys: ["product", "services", "support"],
+          font,
+          tickCount: data.length,
+          labelColor: axisLabelColor,
+          lineWidth: 0,
+          formatYLabel: (value) => String(value),
+        },
+      ]}
+      frame={{ lineWidth: 0 }}
+    >
+      {({ points, chartBounds }) => (
+        <HorizontalStackedBar
+          animate={{ type: "spring" }}
+          chartBounds={chartBounds}
+          innerPadding={innerPadding}
+          points={[points.product, points.services, points.support]}
+          colors={SERIES_COLORS}
+          barOptions={({ isEnd }) => ({
+            roundedCorners: isEnd
+              ? {
+                  topRight: roundedCorner,
+                  bottomRight: roundedCorner,
+                }
+              : undefined,
+          })}
+        />
+      )}
+    </CartesianChart>
+  );
+}
+
+function TouchableSegmentsChart({
+  font,
+  axisLabelColor,
+}: {
+  font: ReturnType<typeof useFont>;
+  axisLabelColor: string;
+}) {
+  const { state, isActive } = useChartPressState({
+    x: "Alpha",
+    y: { product: 0, services: 0, support: 0 },
+  });
+  const selectedDatumIndex = state.matchedIndex.value;
+  const selectedSeriesIndex = state.yIndex.value;
+  const [tooltipText, setTooltipText] = React.useState(
+    "Press a segment to inspect the stack.",
+  );
+
+  useAnimatedReaction(
+    () => ({
+      active: state.isActive.value,
+      category: state.x.value.value,
+      seriesIndex: state.yIndex.value,
+      product: state.y.product.value.value,
+      services: state.y.services.value.value,
+      support: state.y.support.value.value,
+    }),
+    (next) => {
+      if (!next.active) {
+        return;
+      }
+
+      if (next.seriesIndex < 0) {
+        runOnJS(setTooltipText)("No segment at this position.");
+        return;
+      }
+
+      const values = [next.product, next.services, next.support];
+      const label = SERIES_LABELS[next.seriesIndex] ?? "Segment";
+      const value = values[next.seriesIndex] ?? 0;
+
+      runOnJS(setTooltipText)(`${String(next.category)}: ${label} ${value}`);
+    },
+  );
+
+  return (
+    <View style={styles.chartWithTooltip}>
+      <View style={styles.chartFill}>
+        <CartesianChart
+          orientation="horizontal"
+          chartPressState={state}
+          chartPressConfig={{ pan: { activateAfterLongPress: 0 } }}
+          data={TOUCHABLE_DATA}
+          xKey="category"
+          yKeys={["product", "services", "support"]}
+          domain={{ x: [-50, 140] }}
+          domainPadding={{ top: 34, bottom: 34, left: 18, right: 24 }}
+          padding={5}
+          xAxis={{
+            font,
+            tickCount: 5,
+            labelColor: axisLabelColor,
+            linePathEffect: <DashPathEffect intervals={[4, 4]} />,
+            formatXLabel: (value) => `${value}`,
+          }}
+          yAxis={[
+            {
+              yKeys: ["product", "services", "support"],
+              font,
+              tickCount: TOUCHABLE_DATA.length,
+              labelColor: axisLabelColor,
+              lineWidth: 0,
+              formatYLabel: (value) => String(value),
+            },
+          ]}
+          frame={{ lineWidth: 0 }}
+        >
+          {({ points, chartBounds }) => (
+            <HorizontalStackedBar
+              chartBounds={chartBounds}
+              points={[points.product, points.services, points.support]}
+              colors={SERIES_COLORS}
+              barOptions={({ datumIndex, isEnd, seriesIndex }) => {
+                const isSelected =
+                  isActive &&
+                  selectedDatumIndex === datumIndex &&
+                  selectedSeriesIndex === seriesIndex;
+
+                return {
+                  color: isSelected ? "#ec4899" : undefined,
+                  opacity: isActive && !isSelected ? 0.45 : 1,
+                  roundedCorners: isEnd
+                    ? {
+                        topRight: 8,
+                        bottomRight: 8,
+                      }
+                    : undefined,
+                };
+              }}
+            />
+          )}
+        </CartesianChart>
+      </View>
+      <Text style={styles.tooltipText}>{tooltipText}</Text>
+    </View>
+  );
+}
+
+function CustomChildrenChart({
+  font,
+  axisLabelColor,
+}: {
+  font: ReturnType<typeof useFont>;
+  axisLabelColor: string;
+}) {
+  return (
+    <CartesianChart
+      orientation="horizontal"
+      data={CUSTOM_CHILDREN_DATA}
+      xKey="category"
+      yKeys={["product", "services", "support"]}
+      domain={{ x: [0, 150] }}
+      domainPadding={{ top: 38, bottom: 38, left: 16, right: 24 }}
+      padding={5}
+      xAxis={{
+        font,
+        tickCount: 5,
+        labelColor: axisLabelColor,
+        linePathEffect: <DashPathEffect intervals={[4, 4]} />,
+        formatXLabel: (value) => `${value}`,
+      }}
+      yAxis={[
+        {
+          yKeys: ["product", "services", "support"],
+          font,
+          tickCount: CUSTOM_CHILDREN_DATA.length,
+          labelColor: axisLabelColor,
+          lineWidth: 0,
+          formatYLabel: (value) => String(value),
+        },
+      ]}
+      frame={{ lineWidth: 0 }}
+    >
+      {({ points, chartBounds }) => (
+        <HorizontalStackedBar
+          chartBounds={chartBounds}
+          innerPadding={0.42}
+          points={[points.product, points.services, points.support]}
+          colors={SERIES_COLORS}
+          barOptions={({ datumIndex, isEnd, seriesIndex }) => ({
+            roundedCorners: isEnd
+              ? {
+                  topRight: 8,
+                  bottomRight: 8,
+                }
+              : undefined,
+            children:
+              seriesIndex === 1 ? (
+                <LinearGradient
+                  start={vec(0, 0)}
+                  end={vec(260, 0)}
+                  colors={["#818cf8", "#312e81"]}
+                />
+              ) : seriesIndex === 2 && datumIndex === 2 ? (
+                <LinearGradient
+                  start={vec(0, 0)}
+                  end={vec(180, 0)}
+                  colors={["#facc15", "#ea580c"]}
+                />
+              ) : undefined,
+          })}
+        />
+      )}
+    </CartesianChart>
+  );
+}
+
+function NonUniformChart({
+  font,
+  axisLabelColor,
+}: {
+  font: ReturnType<typeof useFont>;
+  axisLabelColor: string;
+}) {
+  return (
+    <CartesianChart
+      orientation="horizontal"
+      data={NON_UNIFORM_DATA}
+      xKey="category"
+      yKeys={["product", "services", "support"]}
+      domain={{ x: [-40, 120] }}
+      domainPadding={{ top: 34, bottom: 34, left: 18, right: 24 }}
+      padding={5}
+      xAxis={{
+        font,
+        tickCount: 5,
+        labelColor: axisLabelColor,
+        linePathEffect: <DashPathEffect intervals={[4, 4]} />,
+        formatXLabel: (value) => `${value}`,
+      }}
+      yAxis={[
+        {
+          yKeys: ["product", "services", "support"],
+          font,
+          tickCount: NON_UNIFORM_DATA.length,
+          labelColor: axisLabelColor,
+          lineWidth: 0,
+          formatYLabel: (value) => String(value),
+        },
+      ]}
+      frame={{ lineWidth: 0 }}
+    >
+      {({ points, chartBounds }) => (
+        <HorizontalStackedBar
+          chartBounds={chartBounds}
+          barWidth={26}
+          points={[points.product, points.services, points.support]}
+          colors={SERIES_COLORS}
+          barOptions={({ isLeft, isRight }) => ({
+            roundedCorners: {
+              topLeft: isLeft ? 7 : 0,
+              bottomLeft: isLeft ? 7 : 0,
+              topRight: isRight ? 7 : 0,
+              bottomRight: isRight ? 7 : 0,
+            },
+          })}
+        />
+      )}
+    </CartesianChart>
+  );
+}
+
+function Legend() {
+  return (
+    <View style={styles.legend}>
+      <LegendItem color={SERIES_COLORS[0]!} label="Product" />
+      <LegendItem color={SERIES_COLORS[1]!} label="Services" />
+      <LegendItem color={SERIES_COLORS[2]!} label="Support" />
+    </View>
+  );
+}
+
+function LegendItem({ color, label }: { color: string; label: string }) {
+  return (
+    <View style={styles.legendItem}>
+      <View style={[styles.swatch, { backgroundColor: color }]} />
+      <Text style={styles.legendText}>{label}</Text>
+    </View>
+  );
+}
+
+function shuffleData(data: ChannelDatum[]) {
+  return data.map((datum) => ({
+    ...datum,
+    product: jitter(datum.product),
+    services: jitter(datum.services),
+    support: jitter(datum.support),
+  }));
+}
+
+function jitter(value: number) {
+  const direction = value < 0 ? -1 : 1;
+  return (
+    direction *
+    Math.max(8, Math.round(Math.abs(value) * (0.7 + Math.random() * 0.6)))
+  );
+}
+
+const styles = StyleSheet.create({
+  safeView: {
+    flex: 1,
+    backgroundColor: appColors.viewBackground.light,
+    $dark: {
+      backgroundColor: appColors.viewBackground.dark,
+    },
+  },
+  scrollView: {
+    flex: 1,
+    backgroundColor: appColors.viewBackground.light,
+    $dark: {
+      backgroundColor: appColors.viewBackground.dark,
+    },
+  },
+  content: {
+    paddingHorizontal: 20,
+    paddingVertical: 15,
+    gap: 24,
+  },
+  section: {
+    gap: 14,
+  },
+  sectionHeader: {
+    gap: 4,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: "bold",
+  },
+  sectionDescription: {
+    fontSize: 14,
+    lineHeight: 19,
+    opacity: 0.72,
+  },
+  largeChart: {
+    height: 360,
+  },
+  mediumChart: {
+    height: 310,
+  },
+  chartWithTooltip: {
+    flex: 1,
+    gap: 8,
+  },
+  chartFill: {
+    flex: 1,
+  },
+  tooltipText: {
+    fontSize: 13,
+    fontWeight: "600",
+    opacity: 0.8,
+  },
+  tallChart: {
+    height: 390,
+  },
+  legend: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 14,
+  },
+  legendItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+  },
+  swatch: {
+    width: 12,
+    height: 12,
+    borderRadius: 2,
+  },
+  legendText: {
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  row: {
+    flexDirection: "row",
+    gap: 12,
+  },
+  rowButton: {
+    flex: 1,
+  },
+});

--- a/example/consts/routes.ts
+++ b/example/consts/routes.ts
@@ -39,6 +39,12 @@ export const ChartRoutes: {
     path: "/horizontal-bar-group",
   },
   {
+    title: "Horizontal Stacked Bar",
+    description:
+      "This chart renders stacked horizontal bars with positive and negative value segments.",
+    path: "/horizontal-stacked-bar",
+  },
+  {
     title: "Bar Group",
     description:
       "This chart demonstrates grouping and displaying multiple sets of data in a Bar chart. Victory supports customizing the spacing between each bar inside the group and spacing around the groups.",

--- a/lib/src/cartesian/CartesianChart.tsx
+++ b/lib/src/cartesian/CartesianChart.tsx
@@ -67,6 +67,7 @@ import { createFallbackChartState } from "./utils/createFallbackChartState";
 import { getCartesianTouchCoordinates } from "./utils/getCartesianTouchCoordinates";
 import { resetChartPressState } from "./utils/resetChartPressState";
 import { getClosestDatumIndex } from "./utils/getClosestDatumIndex";
+import { getStackedBarTouchSegmentIndex } from "./utils/getStackedBarTouchSegmentIndex";
 import {
   type ChartPressBootstrapEntry,
   pruneChartPressBootstrap,
@@ -463,6 +464,9 @@ function CartesianChartContent<
   const chartHeight = chartBounds.bottom;
   const yScaleTop = primaryYAxis.yScale.domain().at(0);
   const yScaleBottom = primaryYAxis.yScale.domain().at(-1);
+  const chartWidth = chartBounds.right - chartBounds.left;
+  const xScaleLeft = xScale.domain().at(0);
+  const xScaleRight = xScale.domain().at(-1);
   // end stacked bar values
 
   /**
@@ -504,7 +508,19 @@ function CartesianChartContent<
       }
 
       if (orientation === "horizontal") {
-        v.yIndex.value = -1;
+        const chartXPressed = x - chartBounds.left;
+        const xDomainValue =
+          chartWidth > 0 &&
+          xScaleLeft !== undefined &&
+          xScaleRight !== undefined
+            ? (chartXPressed / chartWidth) * (xScaleRight - xScaleLeft) +
+              xScaleLeft
+            : NaN;
+
+        v.yIndex.value = getStackedBarTouchSegmentIndex({
+          values: barHeights,
+          touchValue: xDomainValue,
+        });
       } else {
         const chartYPressed = chartHeight - y; // Invert y-coordinate, since RNGH gives us the absolute Y, and we want to know where in the chart they clicked
         // Calculate the actual yValue of the touch within the domain of the yScale
@@ -550,7 +566,19 @@ function CartesianChartContent<
 
       lastIdx.value = idx;
     },
-    [chartHeight, lastIdx, orientation, tData, yKeys, yScaleBottom, yScaleTop],
+    [
+      chartBounds.left,
+      chartHeight,
+      chartWidth,
+      lastIdx,
+      orientation,
+      tData,
+      xScaleLeft,
+      xScaleRight,
+      yKeys,
+      yScaleBottom,
+      yScaleTop,
+    ],
   );
 
   React.useImperativeHandle(

--- a/lib/src/cartesian/CartesianChart.tsx
+++ b/lib/src/cartesian/CartesianChart.tsx
@@ -465,8 +465,8 @@ function CartesianChartContent<
   const yScaleTop = primaryYAxis.yScale.domain().at(0);
   const yScaleBottom = primaryYAxis.yScale.domain().at(-1);
   const chartWidth = chartBounds.right - chartBounds.left;
-  const xScaleLeft = xScale.domain().at(0);
-  const xScaleRight = xScale.domain().at(-1);
+  const xScaleLeft = xScale.invert(chartBounds.left);
+  const xScaleRight = xScale.invert(chartBounds.right);
   // end stacked bar values
 
   /**

--- a/lib/src/cartesian/components/HorizontalStackedBar.tsx
+++ b/lib/src/cartesian/components/HorizontalStackedBar.tsx
@@ -1,0 +1,68 @@
+import * as React from "react";
+import { Path, type Color } from "@shopify/react-native-skia";
+import type { PropsWithChildren } from "react";
+import type { ChartBounds, PointsArray } from "../../types";
+import { AnimatedPath } from "./AnimatedPath";
+import { type PathAnimationConfig } from "../../hooks/useAnimatedPath";
+import { useCartesianChartContext } from "../contexts/CartesianChartContext";
+import {
+  useHorizontalStackedBarPaths,
+  type HorizontalStackedBarOptionsFn,
+  type HorizontalStackedBarPath,
+} from "../hooks/useHorizontalStackedBarPaths";
+
+type CartesianHorizontalStackedBarProps = {
+  points: PointsArray[];
+  chartBounds: ChartBounds;
+  innerPadding?: number;
+  animate?: PathAnimationConfig;
+  barWidth?: number;
+  barCount?: number;
+  colors?: Color[];
+  barOptions?: HorizontalStackedBarOptionsFn;
+};
+
+const DEFAULT_COLORS = ["red", "orange", "blue", "green", "blue", "purple"];
+
+export const HorizontalStackedBar = ({
+  points,
+  chartBounds,
+  animate,
+  innerPadding = 0.25,
+  barWidth,
+  barCount,
+  barOptions,
+  colors = DEFAULT_COLORS,
+}: PropsWithChildren<CartesianHorizontalStackedBarProps>) => {
+  const { orientation } = useCartesianChartContext();
+  const paths = useHorizontalStackedBarPaths({
+    points,
+    chartBounds,
+    innerPadding,
+    barWidth,
+    barCount,
+    barOptions,
+    colors,
+  });
+
+  if (orientation !== "horizontal") {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn(
+        'HorizontalStackedBar must be rendered inside a CartesianChart with orientation="horizontal".',
+      );
+    }
+    return null;
+  }
+
+  return (
+    <>
+      {paths.map((p: HorizontalStackedBarPath) => {
+        return React.createElement(animate ? AnimatedPath : Path, {
+          ...p,
+          style: "fill",
+          ...(Boolean(animate) && { animate }),
+        });
+      })}
+    </>
+  );
+};

--- a/lib/src/cartesian/components/StackedBar.tsx
+++ b/lib/src/cartesian/components/StackedBar.tsx
@@ -1,18 +1,15 @@
 import * as React from "react";
-import { Path, type Color, type PathProps } from "@shopify/react-native-skia";
+import { Path, type Color } from "@shopify/react-native-skia";
 import type { PropsWithChildren } from "react";
 import type { ChartBounds, PointsArray } from "../../types";
 import { AnimatedPath } from "./AnimatedPath";
 import { type PathAnimationConfig } from "../../hooks/useAnimatedPath";
-import { type RoundedCorners } from "../../utils/createRoundedRectPath";
 import {
   useStackedBarPaths,
+  type StackedBarOptionsFn,
   type StackedBarPath,
 } from "../hooks/useStackedBarPaths";
 
-type CustomizablePathProps = Partial<
-  Pick<PathProps, "color" | "blendMode" | "opacity" | "antiAlias">
->;
 type CartesianStackedBarProps = {
   points: PointsArray[];
   chartBounds: ChartBounds;
@@ -21,17 +18,7 @@ type CartesianStackedBarProps = {
   barWidth?: number;
   barCount?: number;
   colors?: Color[];
-  barOptions?: ({
-    columnIndex,
-    rowIndex,
-    isBottom,
-    isTop,
-  }: {
-    isBottom: boolean;
-    isTop: boolean;
-    columnIndex: number;
-    rowIndex: number;
-  }) => CustomizablePathProps & { roundedCorners?: RoundedCorners };
+  barOptions?: StackedBarOptionsFn;
 };
 const DEFAULT_COLORS = ["red", "orange", "blue", "green", "blue", "purple"];
 

--- a/lib/src/cartesian/hooks/useHorizontalStackedBarPaths.ts
+++ b/lib/src/cartesian/hooks/useHorizontalStackedBarPaths.ts
@@ -1,0 +1,123 @@
+import * as React from "react";
+import {
+  Skia,
+  type Color,
+  type PathProps,
+  type SkPath,
+} from "@shopify/react-native-skia";
+import {
+  createRoundedRectPath,
+  type RoundedCorners,
+} from "../../utils/createRoundedRectPath";
+import type { ChartBounds, PointsArray } from "../../types";
+import { useCartesianChartContext } from "../contexts/CartesianChartContext";
+import {
+  getHorizontalStackedBarOptionsContext,
+  getStackedBarSegments,
+  type HorizontalStackedBarOptionsContext,
+} from "../utils/getStackedBarSegments";
+import { getBarThickness } from "../utils/getBarThickness";
+import { getHorizontalStackedBarRect } from "../utils/getHorizontalStackedBarRect";
+
+type HorizontalStackedBarPathProps = Partial<
+  Pick<PathProps, "color" | "blendMode" | "opacity" | "antiAlias">
+>;
+
+const DEFAULT_COLORS = ["red", "orange", "blue", "green", "blue", "purple"];
+
+export type HorizontalStackedBarOptions = HorizontalStackedBarPathProps & {
+  roundedCorners?: RoundedCorners;
+  children?: React.ReactNode;
+};
+
+export type { HorizontalStackedBarOptionsContext };
+
+export type HorizontalStackedBarOptionsFn = (
+  options: HorizontalStackedBarOptionsContext,
+) => HorizontalStackedBarOptions;
+
+export type HorizontalStackedBarPath = {
+  path: SkPath;
+  key: string;
+  color?: Color;
+} & HorizontalStackedBarPathProps & {
+    children?: React.ReactNode;
+  };
+
+const DEFAULT_BAR_OPTIONS: HorizontalStackedBarOptionsFn = () => ({});
+
+type Props = {
+  points: PointsArray[];
+  chartBounds: ChartBounds;
+  innerPadding?: number;
+  barWidth?: number;
+  barCount?: number;
+  colors?: Color[];
+  barOptions?: HorizontalStackedBarOptionsFn;
+};
+
+export const useHorizontalStackedBarPaths = ({
+  points,
+  chartBounds,
+  innerPadding = 0.25,
+  barWidth: customBarWidth,
+  barCount,
+  barOptions = DEFAULT_BAR_OPTIONS,
+  colors = DEFAULT_COLORS,
+}: Props) => {
+  const { xScale } = useCartesianChartContext();
+  const barWidth = getBarThickness({
+    points,
+    axisStart: chartBounds.top,
+    axisEnd: chartBounds.bottom,
+    innerPadding,
+    customBarThickness: customBarWidth,
+    barCount,
+  });
+
+  const paths = React.useMemo(() => {
+    const bars: HorizontalStackedBarPath[] = [];
+    const segments = getStackedBarSegments(points);
+
+    segments.forEach((segment) => {
+      const rect = getHorizontalStackedBarRect({
+        segment,
+        xScale,
+        barWidth,
+      });
+      if (!rect) return;
+
+      const options = barOptions(
+        getHorizontalStackedBarOptionsContext(segment),
+      );
+      const { roundedCorners, color, ...ops } = options;
+
+      const path = Skia.Path.Make();
+      if (roundedCorners) {
+        const nonUniformRoundedRect = createRoundedRectPath(
+          rect.x,
+          rect.y,
+          rect.width,
+          rect.height,
+          roundedCorners,
+          segment.value,
+          "horizontal",
+        );
+        path.addRRect(nonUniformRoundedRect);
+      } else {
+        path.addRect(Skia.XYWHRect(rect.x, rect.y, rect.width, rect.height));
+      }
+
+      bars.push({
+        path,
+        key: `${segment.seriesIndex}-${segment.datumIndex}`,
+        color: color ?? colors[segment.seriesIndex],
+        ...ops,
+      });
+    });
+
+    return bars;
+  }, [barOptions, barWidth, colors, points, xScale]);
+
+  return paths;
+};

--- a/lib/src/cartesian/hooks/useStackedBarPaths.ts
+++ b/lib/src/cartesian/hooks/useStackedBarPaths.ts
@@ -9,15 +9,34 @@ import {
   createRoundedRectPath,
   type RoundedCorners,
 } from "../../utils/createRoundedRectPath";
-import type { ChartBounds, InputFieldType, PointsArray } from "../../types";
+import type { ChartBounds, PointsArray } from "../../types";
 import { useCartesianChartContext } from "../contexts/CartesianChartContext";
+import {
+  getStackedBarSegments,
+  getVerticalStackedBarOptionsContext,
+  type VerticalStackedBarOptionsContext,
+} from "../utils/getStackedBarSegments";
+import { getVerticalStackedBarRect } from "../utils/getVerticalStackedBarRect";
 import { useBarWidth } from "./useBarWidth";
 
-type CustomizablePathProps = Partial<
+export type CustomizablePathProps = Partial<
   Pick<PathProps, "color" | "blendMode" | "opacity" | "antiAlias">
 >;
 
 const DEFAULT_COLORS = ["red", "orange", "blue", "green", "blue", "purple"];
+
+export type StackedBarOptionsContext = VerticalStackedBarOptionsContext;
+
+export type StackedBarOptions = CustomizablePathProps & {
+  roundedCorners?: RoundedCorners;
+  children?: React.ReactNode;
+};
+
+export type StackedBarOptionsFn = (
+  options: StackedBarOptionsContext,
+) => StackedBarOptions;
+
+const DEFAULT_BAR_OPTIONS: StackedBarOptionsFn = () => ({});
 
 export type StackedBarPath = {
   path: SkPath;
@@ -34,17 +53,7 @@ type Props = {
   barWidth?: number;
   barCount?: number;
   colors?: Color[];
-  barOptions?: ({
-    columnIndex,
-    rowIndex,
-    isBottom,
-    isTop,
-  }: {
-    isBottom: boolean;
-    isTop: boolean;
-    columnIndex: number;
-    rowIndex: number;
-  }) => CustomizablePathProps & { roundedCorners?: RoundedCorners };
+  barOptions?: StackedBarOptionsFn;
 };
 
 export const useStackedBarPaths = ({
@@ -53,7 +62,7 @@ export const useStackedBarPaths = ({
   innerPadding = 0.25,
   barWidth: customBarWidth,
   barCount,
-  barOptions = () => ({}),
+  barOptions = DEFAULT_BAR_OPTIONS,
   colors = DEFAULT_COLORS,
 }: Props) => {
   const { yScale } = useCartesianChartContext();
@@ -65,115 +74,46 @@ export const useStackedBarPaths = ({
     barCount,
   });
 
-  // initialize an object that will offset the bars' height's for each x value
-  // so that we know where to start drawing the next bar for each x value
-  const barYPositionOffsetTracker = points.reduce(
-    (acc, points) => {
-      points.map((point) => (acc[point.xValue] = [0, 0]));
-      return acc;
-    },
-    {} as Record<InputFieldType, number[]>,
-  );
-
   const paths = React.useMemo(() => {
     const bars: StackedBarPath[] = [];
-    const xToBottomTopIndexMap = getXToPointIndexMap(points);
+    const segments = getStackedBarSegments(points);
 
-    points.forEach((pointsArray, i) => {
-      pointsArray.forEach((point, j) => {
-        const isBottom = xToBottomTopIndexMap.get(point.x)?.[0] === i;
-        const isTop = xToBottomTopIndexMap.get(point.x)?.[1] === i;
-        const { yValue, x, y } = point;
-        if (typeof y !== "number") return;
-        const isPositive = (yValue ?? 0) > 0;
+    segments.forEach((segment) => {
+      const rect = getVerticalStackedBarRect({
+        segment,
+        yScale,
+        barWidth,
+      });
+      if (!rect) return;
 
-        // call for any additional bar options per bar
-        const options = barOptions({
-          columnIndex: i,
-          rowIndex: j,
-          isBottom: isPositive ? isBottom : isTop,
-          isTop: isPositive ? isTop : isBottom,
-        });
-        const { roundedCorners, color, ...ops } = options;
+      const options = barOptions(getVerticalStackedBarOptionsContext(segment));
+      const { roundedCorners, color, ...ops } = options;
 
-        const path = Skia.Path.Make();
-        const barHeight = yScale(0) - y;
+      const path = Skia.Path.Make();
+      if (roundedCorners) {
+        const nonUniformRoundedRect = createRoundedRectPath(
+          rect.x,
+          rect.y,
+          rect.width,
+          rect.height,
+          roundedCorners,
+          segment.value,
+        );
+        path.addRRect(nonUniformRoundedRect);
+      } else {
+        path.addRect(Skia.XYWHRect(rect.x, rect.y, rect.width, rect.height));
+      }
 
-        const offset = isPositive
-          ? barYPositionOffsetTracker?.[point.xValue!]?.[0]
-          : barYPositionOffsetTracker?.[point.xValue!]?.[1];
-
-        if (roundedCorners) {
-          const nonUniformRoundedRect = createRoundedRectPath(
-            x - barWidth / 2,
-            y - (offset ?? 0),
-            barWidth,
-            barHeight,
-            roundedCorners,
-            Number(yValue),
-          );
-          path.addRRect(nonUniformRoundedRect);
-        } else {
-          path.addRect(
-            Skia.XYWHRect(
-              point.x - barWidth / 2,
-              y - (offset ?? 0),
-              barWidth,
-              barHeight,
-            ),
-          );
-        }
-
-        if (notNullAndUndefined(offset)) {
-          if (isPositive) {
-            barYPositionOffsetTracker[point.xValue!]![0] = barHeight + offset; // accumulate the positive heights as we loop
-          } else {
-            barYPositionOffsetTracker[point.xValue!]![1] = barHeight + offset; // accumulate the negative heights as we loop
-          }
-        }
-
-        const bar = {
-          path,
-          key: `${i}-${j}`,
-          color: color ?? colors[i],
-          ...ops,
-        };
-        bars.push(bar);
+      bars.push({
+        path,
+        key: `${segment.seriesIndex}-${segment.datumIndex}`,
+        color: color ?? colors[segment.seriesIndex],
+        ...ops,
       });
     });
 
     return bars;
-  }, [barOptions, barWidth, barYPositionOffsetTracker, colors, points, yScale]);
+  }, [barOptions, barWidth, colors, points, yScale]);
 
   return paths;
 };
-
-/**
- * Returns a map of x values to a two value array where the first number is the index of
- * the bottom bar and the second is the index of the top bar.
- */
-const getXToPointIndexMap = (
-  points: PointsArray[],
-): Map<number, [number, number]> => {
-  const xToIndexMap = new Map<number, [number, number]>();
-  points.forEach((pointsArray, i) => {
-    pointsArray.forEach(({ x, y, yValue }) => {
-      if (
-        notNullAndUndefined(y) &&
-        notNullAndUndefined(yValue) &&
-        yValue !== 0
-      ) {
-        const current = xToIndexMap.get(x);
-        if (!current) {
-          xToIndexMap.set(x, [i, i]);
-        } else {
-          yValue > 0 ? (current[1] = i) : (current[0] = i);
-        }
-      }
-    });
-  });
-  return xToIndexMap;
-};
-
-const notNullAndUndefined = <T>(value: T | null | undefined): value is T =>
-  value !== null && value !== undefined;

--- a/lib/src/cartesian/utils/getHorizontalStackedBarRect.test.ts
+++ b/lib/src/cartesian/utils/getHorizontalStackedBarRect.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { getStackedBarSegments } from "./getStackedBarSegments";
+import { getHorizontalStackedBarRect } from "./getHorizontalStackedBarRect";
+
+const xScale = (value: number) => 100 + value * 5;
+
+describe("getHorizontalStackedBarRect", () => {
+  it("converts positive stack segments into cumulative horizontal rects", () => {
+    const segments = getStackedBarSegments([
+      [{ x: 120, xValue: "A", y: 80, yValue: 4 }],
+      [{ x: 130, xValue: "A", y: 80, yValue: 6 }],
+    ]);
+
+    expect(
+      getHorizontalStackedBarRect({
+        segment: segments[1]!,
+        xScale,
+        barWidth: 20,
+      }),
+    ).toEqual({
+      x: 120,
+      y: 70,
+      width: 30,
+      height: 20,
+    });
+  });
+
+  it("normalizes negative stack segments to positive rect widths", () => {
+    const segments = getStackedBarSegments([
+      [{ x: 85, xValue: "A", y: 80, yValue: -3 }],
+      [{ x: 90, xValue: "A", y: 80, yValue: -2 }],
+    ]);
+
+    expect(
+      getHorizontalStackedBarRect({
+        segment: segments[1]!,
+        xScale,
+        barWidth: 20,
+      }),
+    ).toEqual({
+      x: 75,
+      y: 70,
+      width: 10,
+      height: 20,
+    });
+  });
+
+  it("returns null when scaled positions are non-finite", () => {
+    const [segment] = getStackedBarSegments([
+      [{ x: 110, xValue: "A", y: 80, yValue: 2 }],
+    ]);
+
+    expect(
+      getHorizontalStackedBarRect({
+        segment: segment!,
+        xScale: () => Number.NaN,
+        barWidth: 20,
+      }),
+    ).toBeNull();
+  });
+});

--- a/lib/src/cartesian/utils/getHorizontalStackedBarRect.ts
+++ b/lib/src/cartesian/utils/getHorizontalStackedBarRect.ts
@@ -1,0 +1,32 @@
+import type { HorizontalBarRect } from "./getHorizontalBarRect";
+import type { StackedBarSegment } from "./getStackedBarSegments";
+
+export const getHorizontalStackedBarRect = ({
+  segment,
+  xScale,
+  barWidth,
+}: {
+  segment: StackedBarSegment;
+  xScale: (value: number) => number;
+  barWidth: number;
+}): HorizontalBarRect | null => {
+  const { y } = segment.point;
+  const startX = xScale(segment.startValue);
+  const endX = xScale(segment.endValue);
+
+  if (
+    typeof y !== "number" ||
+    !Number.isFinite(y) ||
+    !Number.isFinite(startX) ||
+    !Number.isFinite(endX)
+  ) {
+    return null;
+  }
+
+  return {
+    x: Math.min(startX, endX),
+    y: y - barWidth / 2,
+    width: Math.abs(endX - startX),
+    height: barWidth,
+  };
+};

--- a/lib/src/cartesian/utils/getStackedBarSegments.test.ts
+++ b/lib/src/cartesian/utils/getStackedBarSegments.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from "vitest";
+import type { PointsArray } from "../../types";
+import {
+  getHorizontalStackedBarOptionsContext,
+  getStackedBarSegments,
+  getVerticalStackedBarOptionsContext,
+} from "./getStackedBarSegments";
+
+const summarizeSegments = (points: PointsArray[]) =>
+  getStackedBarSegments(points).map(
+    ({
+      categoryKey,
+      value,
+      startValue,
+      endValue,
+      seriesIndex,
+      datumIndex,
+      isPositive,
+      isStart,
+      isEnd,
+    }) => ({
+      categoryKey,
+      value,
+      startValue,
+      endValue,
+      seriesIndex,
+      datumIndex,
+      isPositive,
+      isStart,
+      isEnd,
+    }),
+  );
+
+describe("getStackedBarSegments", () => {
+  it("accumulates positive and negative stacks independently by category", () => {
+    const points: PointsArray[] = [
+      [{ x: 80, xValue: "A", y: 50, yValue: 10 }],
+      [{ x: 80, xValue: "A", y: 75, yValue: 5 }],
+      [{ x: 80, xValue: "A", y: 115, yValue: -3 }],
+      [{ x: 80, xValue: "A", y: 125, yValue: -2 }],
+    ];
+
+    expect(summarizeSegments(points)).toEqual([
+      {
+        categoryKey: "A",
+        value: 10,
+        startValue: 0,
+        endValue: 10,
+        seriesIndex: 0,
+        datumIndex: 0,
+        isPositive: true,
+        isStart: true,
+        isEnd: false,
+      },
+      {
+        categoryKey: "A",
+        value: 5,
+        startValue: 10,
+        endValue: 15,
+        seriesIndex: 1,
+        datumIndex: 0,
+        isPositive: true,
+        isStart: false,
+        isEnd: true,
+      },
+      {
+        categoryKey: "A",
+        value: -3,
+        startValue: 0,
+        endValue: -3,
+        seriesIndex: 2,
+        datumIndex: 0,
+        isPositive: false,
+        isStart: true,
+        isEnd: false,
+      },
+      {
+        categoryKey: "A",
+        value: -2,
+        startValue: -3,
+        endValue: -5,
+        seriesIndex: 3,
+        datumIndex: 0,
+        isPositive: false,
+        isStart: false,
+        isEnd: true,
+      },
+    ]);
+  });
+
+  it("keeps category stacks independent across series", () => {
+    const points: PointsArray[] = [
+      [
+        { x: 80, xValue: "A", y: 50, yValue: 10 },
+        { x: 120, xValue: "B", y: 85, yValue: 3 },
+      ],
+      [
+        { x: 80, xValue: "A", y: 75, yValue: 5 },
+        { x: 120, xValue: "B", y: 110, yValue: -2 },
+      ],
+    ];
+
+    expect(summarizeSegments(points)).toEqual([
+      {
+        categoryKey: "A",
+        value: 10,
+        startValue: 0,
+        endValue: 10,
+        seriesIndex: 0,
+        datumIndex: 0,
+        isPositive: true,
+        isStart: true,
+        isEnd: false,
+      },
+      {
+        categoryKey: "B",
+        value: 3,
+        startValue: 0,
+        endValue: 3,
+        seriesIndex: 0,
+        datumIndex: 1,
+        isPositive: true,
+        isStart: true,
+        isEnd: true,
+      },
+      {
+        categoryKey: "A",
+        value: 5,
+        startValue: 10,
+        endValue: 15,
+        seriesIndex: 1,
+        datumIndex: 0,
+        isPositive: true,
+        isStart: false,
+        isEnd: true,
+      },
+      {
+        categoryKey: "B",
+        value: -2,
+        startValue: 0,
+        endValue: -2,
+        seriesIndex: 1,
+        datumIndex: 1,
+        isPositive: false,
+        isStart: true,
+        isEnd: true,
+      },
+    ]);
+  });
+
+  it("preserves zero-height renderable segments without marking stack ends", () => {
+    const points: PointsArray[] = [
+      [{ x: 80, xValue: "A", y: 100, yValue: 0 }],
+      [{ x: 80, xValue: "A", y: 80, yValue: 4 }],
+    ];
+
+    expect(summarizeSegments(points)).toEqual([
+      {
+        categoryKey: "A",
+        value: 0,
+        startValue: 0,
+        endValue: 0,
+        seriesIndex: 0,
+        datumIndex: 0,
+        isPositive: false,
+        isStart: false,
+        isEnd: false,
+      },
+      {
+        categoryKey: "A",
+        value: 4,
+        startValue: 0,
+        endValue: 4,
+        seriesIndex: 1,
+        datumIndex: 0,
+        isPositive: true,
+        isStart: true,
+        isEnd: true,
+      },
+    ]);
+  });
+
+  it("skips missing and non-finite endpoints", () => {
+    const points: PointsArray[] = [
+      [
+        { x: 80, xValue: "A", y: null, yValue: 2 },
+        { x: Number.NaN, xValue: "B", y: 80, yValue: 2 },
+        { x: 120, xValue: "C", y: 70, yValue: undefined },
+      ],
+    ];
+
+    expect(summarizeSegments(points)).toEqual([
+      {
+        categoryKey: "C",
+        value: 0,
+        startValue: 0,
+        endValue: 0,
+        seriesIndex: 0,
+        datumIndex: 2,
+        isPositive: false,
+        isStart: false,
+        isEnd: false,
+      },
+    ]);
+  });
+
+  it("maps neutral edge fields to vertical bottom/top fields", () => {
+    const segments = getStackedBarSegments([
+      [{ x: 80, xValue: "A", y: 50, yValue: 10 }],
+      [{ x: 80, xValue: "A", y: 75, yValue: 5 }],
+      [{ x: 80, xValue: "A", y: 115, yValue: -3 }],
+      [{ x: 80, xValue: "A", y: 125, yValue: -2 }],
+    ]);
+
+    expect(segments.map(getVerticalStackedBarOptionsContext)).toEqual([
+      {
+        columnIndex: 0,
+        rowIndex: 0,
+        seriesIndex: 0,
+        datumIndex: 0,
+        isStart: true,
+        isEnd: false,
+        isBottom: true,
+        isTop: false,
+      },
+      {
+        columnIndex: 1,
+        rowIndex: 0,
+        seriesIndex: 1,
+        datumIndex: 0,
+        isStart: false,
+        isEnd: true,
+        isBottom: false,
+        isTop: true,
+      },
+      {
+        columnIndex: 2,
+        rowIndex: 0,
+        seriesIndex: 2,
+        datumIndex: 0,
+        isStart: true,
+        isEnd: false,
+        isBottom: false,
+        isTop: true,
+      },
+      {
+        columnIndex: 3,
+        rowIndex: 0,
+        seriesIndex: 3,
+        datumIndex: 0,
+        isStart: false,
+        isEnd: true,
+        isBottom: true,
+        isTop: false,
+      },
+    ]);
+  });
+
+  it("maps neutral edge fields to horizontal left/right fields", () => {
+    const segments = getStackedBarSegments([
+      [{ x: 80, xValue: "A", y: 50, yValue: 10 }],
+      [{ x: 80, xValue: "A", y: 75, yValue: 5 }],
+      [{ x: 80, xValue: "A", y: 115, yValue: -3 }],
+      [{ x: 80, xValue: "A", y: 125, yValue: -2 }],
+    ]);
+
+    expect(segments.map(getHorizontalStackedBarOptionsContext)).toEqual([
+      {
+        columnIndex: 0,
+        rowIndex: 0,
+        seriesIndex: 0,
+        datumIndex: 0,
+        isStart: true,
+        isEnd: false,
+        isLeft: true,
+        isRight: false,
+      },
+      {
+        columnIndex: 1,
+        rowIndex: 0,
+        seriesIndex: 1,
+        datumIndex: 0,
+        isStart: false,
+        isEnd: true,
+        isLeft: false,
+        isRight: true,
+      },
+      {
+        columnIndex: 2,
+        rowIndex: 0,
+        seriesIndex: 2,
+        datumIndex: 0,
+        isStart: true,
+        isEnd: false,
+        isLeft: false,
+        isRight: true,
+      },
+      {
+        columnIndex: 3,
+        rowIndex: 0,
+        seriesIndex: 3,
+        datumIndex: 0,
+        isStart: false,
+        isEnd: true,
+        isLeft: true,
+        isRight: false,
+      },
+    ]);
+  });
+});

--- a/lib/src/cartesian/utils/getStackedBarSegments.ts
+++ b/lib/src/cartesian/utils/getStackedBarSegments.ts
@@ -1,0 +1,175 @@
+import type { InputFieldType, PointsArray } from "../../types";
+
+type Point = PointsArray[number];
+
+export type StackedBarSegment = {
+  point: Point;
+  categoryKey: InputFieldType;
+  value: number;
+  startValue: number;
+  endValue: number;
+  seriesIndex: number;
+  datumIndex: number;
+  isPositive: boolean;
+  isStart: boolean;
+  isEnd: boolean;
+};
+
+export type StackedBarOptionsBaseContext = {
+  columnIndex: number;
+  rowIndex: number;
+  isStart: boolean;
+  isEnd: boolean;
+  seriesIndex: number;
+  datumIndex: number;
+};
+
+export type VerticalStackedBarOptionsContext = StackedBarOptionsBaseContext & {
+  isBottom: boolean;
+  isTop: boolean;
+};
+
+export type HorizontalStackedBarOptionsContext =
+  StackedBarOptionsBaseContext & {
+    isLeft: boolean;
+    isRight: boolean;
+  };
+
+type CategoryStack = {
+  positiveTotal: number;
+  negativeTotal: number;
+  positiveSegments: StackedBarSegment[];
+  negativeSegments: StackedBarSegment[];
+};
+
+export const getStackedBarSegments = (
+  points: PointsArray[],
+): StackedBarSegment[] => {
+  const stacksByCategory = new Map<InputFieldType, CategoryStack>();
+  const segments: StackedBarSegment[] = [];
+
+  points.forEach((pointsArray, seriesIndex) => {
+    pointsArray.forEach((point, datumIndex) => {
+      if (!hasRenderableEndpoint(point)) return;
+
+      const categoryKey = point.xValue;
+      const stack = getCategoryStack(stacksByCategory, categoryKey);
+      const value = getFiniteValue(point.yValue);
+
+      if (value === 0) {
+        segments.push({
+          point,
+          categoryKey,
+          value,
+          startValue: 0,
+          endValue: 0,
+          seriesIndex,
+          datumIndex,
+          isPositive: false,
+          isStart: false,
+          isEnd: false,
+        });
+        return;
+      }
+
+      const isPositive = value > 0;
+      const signSegments = isPositive
+        ? stack.positiveSegments
+        : stack.negativeSegments;
+      const startValue = isPositive ? stack.positiveTotal : stack.negativeTotal;
+      const endValue = startValue + value;
+      const segment: StackedBarSegment = {
+        point,
+        categoryKey,
+        value,
+        startValue,
+        endValue,
+        seriesIndex,
+        datumIndex,
+        isPositive,
+        isStart: signSegments.length === 0,
+        isEnd: false,
+      };
+
+      signSegments.push(segment);
+      segments.push(segment);
+
+      if (isPositive) {
+        stack.positiveTotal = endValue;
+      } else {
+        stack.negativeTotal = endValue;
+      }
+    });
+  });
+
+  stacksByCategory.forEach(({ positiveSegments, negativeSegments }) => {
+    const positiveEnd = positiveSegments.at(-1);
+    const negativeEnd = negativeSegments.at(-1);
+
+    if (positiveEnd) positiveEnd.isEnd = true;
+    if (negativeEnd) negativeEnd.isEnd = true;
+  });
+
+  return segments;
+};
+
+export const getVerticalStackedBarOptionsContext = (
+  segment: StackedBarSegment,
+): VerticalStackedBarOptionsContext => {
+  const { seriesIndex, datumIndex, isPositive, isStart, isEnd } = segment;
+
+  return {
+    columnIndex: seriesIndex,
+    rowIndex: datumIndex,
+    seriesIndex,
+    datumIndex,
+    isStart,
+    isEnd,
+    isBottom: isPositive ? isStart : isEnd,
+    isTop: isPositive ? isEnd : isStart,
+  };
+};
+
+export const getHorizontalStackedBarOptionsContext = (
+  segment: StackedBarSegment,
+): HorizontalStackedBarOptionsContext => {
+  const { seriesIndex, datumIndex, isPositive, isStart, isEnd } = segment;
+
+  return {
+    columnIndex: seriesIndex,
+    rowIndex: datumIndex,
+    seriesIndex,
+    datumIndex,
+    isStart,
+    isEnd,
+    isLeft: isPositive ? isStart : isEnd,
+    isRight: isPositive ? isEnd : isStart,
+  };
+};
+
+const getCategoryStack = (
+  stacksByCategory: Map<InputFieldType, CategoryStack>,
+  categoryKey: InputFieldType,
+): CategoryStack => {
+  const stack = stacksByCategory.get(categoryKey);
+
+  if (stack) return stack;
+
+  const nextStack: CategoryStack = {
+    positiveTotal: 0,
+    negativeTotal: 0,
+    positiveSegments: [],
+    negativeSegments: [],
+  };
+  stacksByCategory.set(categoryKey, nextStack);
+
+  return nextStack;
+};
+
+const hasRenderableEndpoint = (point: Point) =>
+  typeof point.y === "number" &&
+  Number.isFinite(point.x) &&
+  Number.isFinite(point.y);
+
+const getFiniteValue = (value: Point["yValue"]) =>
+  typeof value === "number" && Number.isFinite(value) ? value : 0;

--- a/lib/src/cartesian/utils/getStackedBarTouchSegmentIndex.test.ts
+++ b/lib/src/cartesian/utils/getStackedBarTouchSegmentIndex.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { getCartesianChartBounds } from "./getCartesianChartBounds";
 import { getStackedBarTouchSegmentIndex } from "./getStackedBarTouchSegmentIndex";
+import { makeScale } from "./makeScale";
 
 describe("getStackedBarTouchSegmentIndex", () => {
   it("finds the touched positive segment from cumulative values", () => {
@@ -55,6 +57,53 @@ describe("getStackedBarTouchSegmentIndex", () => {
       getStackedBarTouchSegmentIndex({
         values: [-10, -20],
         touchValue: -40,
+      }),
+    ).toBe(-1);
+  });
+
+  it("selects horizontal segments from viewport-adjusted chart coordinates", () => {
+    const xScale = makeScale({
+      inputBounds: [0, 100],
+      outputBounds: [0, 200],
+      viewport: [20, 60],
+      padStart: 10,
+      padEnd: 10,
+    });
+    const yScale = makeScale({
+      inputBounds: [0, 1],
+      outputBounds: [0, 100],
+    });
+    const chartBounds = getCartesianChartBounds({
+      xScale,
+      yScale,
+      viewport: { x: [20, 60] },
+      domainPadding: { left: 10, right: 10 },
+      orientation: "horizontal",
+    });
+    const touchX = 150;
+    const visibleDomainLeft = xScale.invert(chartBounds.left);
+    const visibleDomainRight = xScale.invert(chartBounds.right);
+    const touchValue =
+      ((touchX - chartBounds.left) / (chartBounds.right - chartBounds.left)) *
+        (visibleDomainRight - visibleDomainLeft) +
+      visibleDomainLeft;
+
+    expect(xScale.domain()).toEqual([0, 100]);
+    expect(touchValue).toBeCloseTo(51.111);
+    expect(
+      getStackedBarTouchSegmentIndex({
+        values: [30, 30],
+        touchValue,
+      }),
+    ).toBe(1);
+
+    const fullDomainTouchValue =
+      ((touchX - chartBounds.left) / (chartBounds.right - chartBounds.left)) *
+      100;
+    expect(
+      getStackedBarTouchSegmentIndex({
+        values: [30, 30],
+        touchValue: fullDomainTouchValue,
       }),
     ).toBe(-1);
   });

--- a/lib/src/cartesian/utils/getStackedBarTouchSegmentIndex.test.ts
+++ b/lib/src/cartesian/utils/getStackedBarTouchSegmentIndex.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { getStackedBarTouchSegmentIndex } from "./getStackedBarTouchSegmentIndex";
+
+describe("getStackedBarTouchSegmentIndex", () => {
+  it("finds the touched positive segment from cumulative values", () => {
+    expect(
+      getStackedBarTouchSegmentIndex({
+        values: [10, 20, 30],
+        touchValue: 25,
+      }),
+    ).toBe(1);
+  });
+
+  it("finds the touched negative segment from cumulative values", () => {
+    expect(
+      getStackedBarTouchSegmentIndex({
+        values: [-10, -20, -30],
+        touchValue: -25,
+      }),
+    ).toBe(1);
+  });
+
+  it("keeps positive and negative stacks independent", () => {
+    expect(
+      getStackedBarTouchSegmentIndex({
+        values: [10, -20, 30],
+        touchValue: 25,
+      }),
+    ).toBe(2);
+    expect(
+      getStackedBarTouchSegmentIndex({
+        values: [10, -20, 30],
+        touchValue: -12,
+      }),
+    ).toBe(1);
+  });
+
+  it("skips zero and non-finite values", () => {
+    expect(
+      getStackedBarTouchSegmentIndex({
+        values: [0, Number.NaN, 10],
+        touchValue: 4,
+      }),
+    ).toBe(2);
+  });
+
+  it("returns -1 when the touch is outside the stack", () => {
+    expect(
+      getStackedBarTouchSegmentIndex({
+        values: [10, 20],
+        touchValue: 40,
+      }),
+    ).toBe(-1);
+    expect(
+      getStackedBarTouchSegmentIndex({
+        values: [-10, -20],
+        touchValue: -40,
+      }),
+    ).toBe(-1);
+  });
+});

--- a/lib/src/cartesian/utils/getStackedBarTouchSegmentIndex.ts
+++ b/lib/src/cartesian/utils/getStackedBarTouchSegmentIndex.ts
@@ -1,0 +1,33 @@
+export const getStackedBarTouchSegmentIndex = ({
+  values,
+  touchValue,
+}: {
+  values: number[];
+  touchValue: number;
+}) => {
+  "worklet";
+  if (!Number.isFinite(touchValue) || touchValue === 0) return -1;
+
+  let cumulativeValue = 0;
+  const isPositiveTouch = touchValue > 0;
+
+  for (let i = 0; i < values.length; i++) {
+    const value = values[i] ?? NaN;
+    if (!Number.isFinite(value) || value === 0) continue;
+    if (value > 0 !== isPositiveTouch) continue;
+
+    const startValue = cumulativeValue;
+    const endValue = cumulativeValue + value;
+
+    if (
+      (isPositiveTouch && touchValue >= startValue && touchValue <= endValue) ||
+      (!isPositiveTouch && touchValue <= startValue && touchValue >= endValue)
+    ) {
+      return i;
+    }
+
+    cumulativeValue = endValue;
+  }
+
+  return -1;
+};

--- a/lib/src/cartesian/utils/getVerticalStackedBarRect.test.ts
+++ b/lib/src/cartesian/utils/getVerticalStackedBarRect.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { getStackedBarSegments } from "./getStackedBarSegments";
+import { getVerticalStackedBarRect } from "./getVerticalStackedBarRect";
+
+const yScale = (value: number) => 100 - value * 5;
+
+describe("getVerticalStackedBarRect", () => {
+  it("converts positive stack segments into cumulative vertical rects", () => {
+    const segments = getStackedBarSegments([
+      [{ x: 80, xValue: "A", y: 80, yValue: 4 }],
+      [{ x: 80, xValue: "A", y: 70, yValue: 6 }],
+    ]);
+
+    expect(
+      getVerticalStackedBarRect({
+        segment: segments[1]!,
+        yScale,
+        barWidth: 20,
+      }),
+    ).toEqual({
+      x: 70,
+      y: 50,
+      width: 20,
+      height: 30,
+    });
+  });
+
+  it("preserves negative height direction for downstream corner handling", () => {
+    const segments = getStackedBarSegments([
+      [{ x: 80, xValue: "A", y: 115, yValue: -3 }],
+      [{ x: 80, xValue: "A", y: 130, yValue: -2 }],
+    ]);
+
+    expect(
+      getVerticalStackedBarRect({
+        segment: segments[1]!,
+        yScale,
+        barWidth: 20,
+      }),
+    ).toEqual({
+      x: 70,
+      y: 125,
+      width: 20,
+      height: -10,
+    });
+  });
+
+  it("returns null when scaled positions are non-finite", () => {
+    const [segment] = getStackedBarSegments([
+      [{ x: 80, xValue: "A", y: 90, yValue: 2 }],
+    ]);
+
+    expect(
+      getVerticalStackedBarRect({
+        segment: segment!,
+        yScale: () => Number.NaN,
+        barWidth: 20,
+      }),
+    ).toBeNull();
+  });
+});

--- a/lib/src/cartesian/utils/getVerticalStackedBarRect.ts
+++ b/lib/src/cartesian/utils/getVerticalStackedBarRect.ts
@@ -1,0 +1,31 @@
+import type { VerticalBarRect } from "./getVerticalBarRect";
+import type { StackedBarSegment } from "./getStackedBarSegments";
+
+export const getVerticalStackedBarRect = ({
+  segment,
+  yScale,
+  barWidth,
+}: {
+  segment: StackedBarSegment;
+  yScale: (value: number) => number;
+  barWidth: number;
+}): VerticalBarRect | null => {
+  const { x } = segment.point;
+  const startY = yScale(segment.startValue);
+  const endY = yScale(segment.endValue);
+
+  if (
+    !Number.isFinite(x) ||
+    !Number.isFinite(startY) ||
+    !Number.isFinite(endY)
+  ) {
+    return null;
+  }
+
+  return {
+    x: x - barWidth / 2,
+    y: endY,
+    width: barWidth,
+    height: startY - endY,
+  };
+};

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -72,7 +72,13 @@ export { Bar } from "./cartesian/components/Bar";
 export { HorizontalBar } from "./cartesian/components/HorizontalBar";
 
 // StackedBar
-export { useStackedBarPaths } from "./cartesian/hooks/useStackedBarPaths";
+export {
+  useStackedBarPaths,
+  type StackedBarOptions,
+  type StackedBarOptionsContext,
+  type StackedBarOptionsFn,
+  type StackedBarPath,
+} from "./cartesian/hooks/useStackedBarPaths";
 export { StackedBar } from "./cartesian/components/StackedBar";
 
 // Bar group

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -80,6 +80,14 @@ export {
   type StackedBarPath,
 } from "./cartesian/hooks/useStackedBarPaths";
 export { StackedBar } from "./cartesian/components/StackedBar";
+export {
+  useHorizontalStackedBarPaths,
+  type HorizontalStackedBarOptions,
+  type HorizontalStackedBarOptionsContext,
+  type HorizontalStackedBarOptionsFn,
+  type HorizontalStackedBarPath,
+} from "./cartesian/hooks/useHorizontalStackedBarPaths";
+export { HorizontalStackedBar } from "./cartesian/components/HorizontalStackedBar";
 
 // Bar group
 export { useBarGroupPaths } from "./cartesian/hooks/useBarGroupPaths";

--- a/lib/type-tests/stacked-bar-options-types.tsx
+++ b/lib/type-tests/stacked-bar-options-types.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+import {
+  StackedBar,
+  useStackedBarPaths,
+  type ChartBounds,
+  type PointsArray,
+  type StackedBarOptionsContext,
+} from "victory-native";
+
+const POINTS: PointsArray[] = [];
+const CHART_BOUNDS: ChartBounds = {
+  left: 0,
+  right: 100,
+  top: 0,
+  bottom: 100,
+};
+
+const getOpacity = ({
+  columnIndex,
+  rowIndex,
+  isBottom,
+  isTop,
+  isStart,
+  isEnd,
+  seriesIndex,
+  datumIndex,
+}: StackedBarOptionsContext) => {
+  const legacyIndexesMatch =
+    columnIndex === seriesIndex && rowIndex === datumIndex;
+  const hasVisibleEdge = isBottom || isTop || isStart || isEnd;
+
+  return legacyIndexesMatch && hasVisibleEdge ? 1 : 0.5;
+};
+
+export function StackedBarOptionsFields() {
+  return (
+    <StackedBar
+      points={POINTS}
+      chartBounds={CHART_BOUNDS}
+      barOptions={(context) => ({
+        opacity: getOpacity(context),
+        roundedCorners: context.isEnd ? { topLeft: 4, topRight: 4 } : undefined,
+      })}
+    />
+  );
+}
+
+export function UseStackedBarPathsOptionsFields() {
+  useStackedBarPaths({
+    points: POINTS,
+    chartBounds: CHART_BOUNDS,
+    barOptions: (context) => ({
+      opacity: getOpacity(context),
+      children: context.seriesIndex === 0 ? null : undefined,
+    }),
+  });
+
+  return null;
+}

--- a/lib/type-tests/stacked-bar-options-types.tsx
+++ b/lib/type-tests/stacked-bar-options-types.tsx
@@ -1,8 +1,11 @@
 import * as React from "react";
 import {
+  HorizontalStackedBar,
   StackedBar,
+  useHorizontalStackedBarPaths,
   useStackedBarPaths,
   type ChartBounds,
+  type HorizontalStackedBarOptionsContext,
   type PointsArray,
   type StackedBarOptionsContext,
 } from "victory-native";
@@ -51,6 +54,51 @@ export function UseStackedBarPathsOptionsFields() {
     chartBounds: CHART_BOUNDS,
     barOptions: (context) => ({
       opacity: getOpacity(context),
+      children: context.seriesIndex === 0 ? null : undefined,
+    }),
+  });
+
+  return null;
+}
+
+const getHorizontalOpacity = ({
+  columnIndex,
+  rowIndex,
+  isLeft,
+  isRight,
+  isStart,
+  isEnd,
+  seriesIndex,
+  datumIndex,
+}: HorizontalStackedBarOptionsContext) => {
+  const legacyIndexesMatch =
+    columnIndex === seriesIndex && rowIndex === datumIndex;
+  const hasVisibleEdge = isLeft || isRight || isStart || isEnd;
+
+  return legacyIndexesMatch && hasVisibleEdge ? 1 : 0.5;
+};
+
+export function HorizontalStackedBarOptionsFields() {
+  return (
+    <HorizontalStackedBar
+      points={POINTS}
+      chartBounds={CHART_BOUNDS}
+      barOptions={(context) => ({
+        opacity: getHorizontalOpacity(context),
+        roundedCorners: context.isEnd
+          ? { topRight: 4, bottomRight: 4 }
+          : undefined,
+      })}
+    />
+  );
+}
+
+export function UseHorizontalStackedBarPathsOptionsFields() {
+  useHorizontalStackedBarPaths({
+    points: POINTS,
+    chartBounds: CHART_BOUNDS,
+    barOptions: (context) => ({
+      opacity: getHorizontalOpacity(context),
       children: context.seriesIndex === 0 ? null : undefined,
     }),
   });

--- a/website/docs/cartesian/bar/horizontal-bar-group.md
+++ b/website/docs/cartesian/bar/horizontal-bar-group.md
@@ -117,4 +117,6 @@ The component passes the following paint props to the underlying Skia `Path`:
 - Bars within a category group are offset along the vertical screen axis.
 - Positive values extend right from zero.
 - Negative values extend left from zero.
-- Stacked horizontal bars are not part of this component.
+- For stacked horizontal bars, use [`HorizontalStackedBar`](./horizontal-stacked-bar.md).
+
+When using `chartPressState`, horizontal grouped bars use the same data-semantic press values documented in [`HorizontalBar`](./horizontal-bar.md). The example app's horizontal grouped route includes an active-row tooltip readout built from `state.x` and the grouped series values.

--- a/website/docs/cartesian/bar/horizontal-bar.md
+++ b/website/docs/cartesian/bar/horizontal-bar.md
@@ -73,4 +73,4 @@ When using `chartPressState`, the press values keep their data-semantic names:
 - `state.y[key].value.value` is the numeric series value.
 - `state.y[key].position.value` is the value's horizontal screen position.
 
-For grouped horizontal bars, use [`HorizontalBarGroup`](./horizontal-bar-group.md). Stacked horizontal bars are not part of the initial horizontal bar components; use `StackedBar` for vertical stacked bars.
+For grouped horizontal bars, use [`HorizontalBarGroup`](./horizontal-bar-group.md). For stacked horizontal bars, use [`HorizontalStackedBar`](./horizontal-stacked-bar.md).

--- a/website/docs/cartesian/bar/horizontal-stacked-bar.md
+++ b/website/docs/cartesian/bar/horizontal-stacked-bar.md
@@ -1,0 +1,133 @@
+# `HorizontalStackedBar` (Component)
+
+The `HorizontalStackedBar` component draws stacked horizontal bars inside a `CartesianChart` with `orientation="horizontal"`.
+
+Horizontal stacked bars use the same data shape as vertical stacked bars: `xKey` identifies the category field, and `yKeys` identify the numeric value fields to stack. In horizontal mode, categories render on the vertical axis and stacked values render on the horizontal axis.
+
+## Example
+
+```tsx
+import { CartesianChart, HorizontalStackedBar } from "victory-native";
+
+const DATA = [
+  { category: "North", product: 72, services: 44, support: 28 },
+  { category: "West", product: 58, services: 62, support: 34 },
+  { category: "South", product: 41, services: 38, support: 46 },
+  { category: "East", product: 67, services: 52, support: 31 },
+];
+
+export function MyChart() {
+  return (
+    <CartesianChart
+      orientation="horizontal"
+      data={DATA}
+      xKey="category"
+      yKeys={["product", "services", "support"]}
+      domain={{ x: [0, 170] }}
+      domainPadding={{ top: 36, bottom: 36, right: 24 }}
+      xAxis={{ tickCount: 5 }}
+      yAxis={[{ yKeys: ["product", "services", "support"] }]}
+    >
+      {({ points, chartBounds }) => (
+        <HorizontalStackedBar
+          points={[points.product, points.services, points.support]}
+          chartBounds={chartBounds}
+          colors={["teal", "purple", "orange"]}
+          barOptions={({ isEnd }) => ({
+            roundedCorners: isEnd
+              ? { topRight: 8, bottomRight: 8 }
+              : undefined,
+          })}
+        />
+      )}
+    </CartesianChart>
+  );
+}
+```
+
+## Props
+
+- `points`: an array of `PointsArray` values from the `CartesianChart` render function. The order should match the intended stack order.
+- `chartBounds`: the `chartBounds` render argument from `CartesianChart`.
+- `innerPadding`: controls the vertical space between stacked bars when `barWidth` is not set.
+- `animate`: path animation config.
+- `barWidth`: fixed visual bar thickness.
+- `barCount`: computes thickness as if there were a fixed number of bars.
+- `colors`: segment colors. The order should match the `points` prop.
+- `barOptions`: render options for each stack segment.
+
+## `useHorizontalStackedBarPaths`
+
+`HorizontalStackedBar` is built on top of the exported `useHorizontalStackedBarPaths` hook. Use the hook directly when you need custom Skia rendering but want the built-in horizontal stacking geometry:
+
+```tsx
+const paths = useHorizontalStackedBarPaths({
+  points: [points.product, points.services, points.support],
+  chartBounds,
+  innerPadding: 0.25,
+  barWidth: 24,
+  colors: ["teal", "purple", "orange"],
+  barOptions: ({ isEnd }) => ({
+    roundedCorners: isEnd ? { topRight: 8, bottomRight: 8 } : undefined,
+  }),
+});
+```
+
+The hook returns `HorizontalStackedBarPath[]`, where each entry contains the Skia `path`, a stable `key`, optional `color`, paint props, and optional `children`.
+
+## `barOptions`
+
+```tsx
+barOptions?: ({
+  columnIndex,
+  rowIndex,
+  isStart,
+  isEnd,
+  isLeft,
+  isRight,
+  seriesIndex,
+  datumIndex,
+}: {
+  columnIndex: number;
+  rowIndex: number;
+  isStart: boolean;
+  isEnd: boolean;
+  isLeft: boolean;
+  isRight: boolean;
+  seriesIndex: number;
+  datumIndex: number;
+}) => CustomizablePathProps & {
+  roundedCorners?: RoundedCorners;
+  children?: React.ReactNode;
+};
+```
+
+`seriesIndex` and `datumIndex` identify the rendered series and datum. `columnIndex` and `rowIndex` are backwards-compatible aliases for the same values. `isStart` identifies the segment closest to the zero baseline for that positive or negative stack, and `isEnd` identifies the outer visible value end. `isLeft` and `isRight` are screen-side aliases derived from those neutral fields.
+
+For value-end rounding, use `isEnd` with right-side corners. Negative horizontal segments automatically flip right-side corner radii to the left side:
+
+```tsx
+barOptions={({ isEnd }) => ({
+  roundedCorners: isEnd ? { topRight: 8, bottomRight: 8 } : undefined,
+})}
+```
+
+## Horizontal Mode Notes
+
+- `domain.x`, `viewport.x`, and `domainPadding.left/right` apply to the numeric value axis.
+- `domainPadding.top/bottom` apply to category spacing.
+- Positive stacks accumulate to the right from `xScale(0)`.
+- Negative stacks accumulate to the left from `xScale(0)`.
+- Missing values are skipped.
+- Zero values render as zero-width segments.
+- `points[key].x` is the individual value endpoint on screen.
+- `points[key].y` is the category center on screen.
+- `points[key].xValue` remains the raw category value.
+- `points[key].yValue` remains the raw numeric value.
+- `HorizontalStackedBar` is only supported inside `CartesianChart orientation="horizontal"`.
+
+As with vertical `StackedBar`, set an explicit value domain when the cumulative stack total exceeds the largest individual series value.
+
+When using `chartPressState`, `state.yIndex.value` identifies the touched stack segment by `seriesIndex` for the selected category. Positive and negative stacks are matched independently from the zero baseline.
+
+The example app includes horizontal stacked examples for mixed positive/negative values, pressable segment highlighting, custom Skia children, and missing or zero-valued segments.

--- a/website/docs/cartesian/bar/overview.md
+++ b/website/docs/cartesian/bar/overview.md
@@ -1,0 +1,31 @@
+# Bar Charts Overview
+
+Victory Native includes vertical and horizontal bar marks for single-series, grouped, and stacked Cartesian bar charts.
+
+## Components
+
+| Chart shape | Vertical component | Horizontal component |
+| --- | --- | --- |
+| Single series | [`Bar`](./bar.md) | [`HorizontalBar`](./horizontal-bar.md) |
+| Grouped series | [`BarGroup`](./bar-group.md) | [`HorizontalBarGroup`](./horizontal-bar-group.md) |
+| Stacked series | [`StackedBar`](./stacked-bar.md) | [`HorizontalStackedBar`](./horizontal-stacked-bar.md) |
+
+Use `CartesianChart orientation="horizontal"` with the horizontal components. Horizontal bar charts keep the same data model as vertical bar charts: `xKey` identifies the category field, and `yKeys` identify numeric value fields. The chart renders categories on the vertical screen axis and numeric values on the horizontal screen axis.
+
+## Interaction Support
+
+`chartPressState` works with horizontal bar charts using data-semantic field names:
+
+- `state.x.value.value` is the raw `xKey` category.
+- `state.x.position.value` is the category's vertical screen position.
+- `state.y[key].value.value` is the numeric series value.
+- `state.y[key].position.value` is the value's horizontal screen position.
+- For stacked bars, `state.yIndex.value` identifies the touched stack segment by series index.
+
+The example app includes horizontal bar, horizontal grouped bar, and horizontal stacked bar routes with positive, negative, mixed, custom styling, and press/tooltip examples.
+
+## Current Scope
+
+Horizontal mode is intended for bar marks. Do not expect line, area, stacked area, or scatter marks to transpose just because the parent chart has `orientation="horizontal"`.
+
+The current horizontal bar implementation is centered on linear value axes with a zero baseline. Log value scales, custom non-zero baselines, multi-axis horizontal value charts, and category viewport/windowing are later parity work.

--- a/website/docs/cartesian/bar/stacked-bar.md
+++ b/website/docs/cartesian/bar/stacked-bar.md
@@ -1,6 +1,6 @@
 # `StackedBar` (Component)
 
-The `StackedBar` component takes an **array of `Points[]`** as `points`, a `ChartBounds` object, a `colors` array, a `barOptions` render prop to customize each bar/row/column, and some options for styling/animating, and returns a Skia `Path` element which draws the stacked bar chart.
+The `StackedBar` component takes an **array of `Points[]`** as `points`, a `ChartBounds` object, a `colors` array, a `barOptions` render prop to customize each stack segment, and some options for styling/animating, and returns a Skia `Path` element which draws the stacked bar chart.
 
 <div className="w-96 mx-auto rounded-md overflow-hidden">
 
@@ -17,7 +17,7 @@ The [example app](https://github.com/FormidableLabs/victory-native-xl/tree/main/
 ## Example
 
 ```tsx
-import { CartesianChart, Bar } from "victory-native";
+import { CartesianChart, StackedBar } from "victory-native";
 
 const DATA = (length: number = 10) =>
   Array.from({ length }, (_, index) => ({
@@ -91,7 +91,7 @@ A `ChartBounds` object needed to appropriately draw the bars. This generally com
 
 ### `innerPadding`
 
-An optional `number` between 0 and 1 that represents what fraction of the horizontal space between the first and last bars should be "white space". Defaults to `0.2`. Use `0` for no gap between bars, and values closer to `1` to make bars increasingly narrow.
+An optional `number` between 0 and 1 that represents what fraction of the horizontal space between the first and last bars should be "white space". Defaults to `0.25`. Use `0` for no gap between bars, and values closer to `1` to make bars increasingly narrow.
 
 ### `animate`
 
@@ -122,12 +122,25 @@ barOptions?: ({
     rowIndex,
     isBottom,
     isTop,
+    seriesIndex,
+    datumIndex,
+    isStart,
+    isEnd,
   }: {
     isBottom: boolean;
     isTop: boolean;
     columnIndex: number;
     rowIndex: number;
-  }) => CustomizablePathProps & { roundedCorners?: RoundedCorners };
+    isStart: boolean;
+    isEnd: boolean;
+    seriesIndex: number;
+    datumIndex: number;
+  }) => CustomizablePathProps & {
+    roundedCorners?: RoundedCorners;
+    children?: React.ReactNode;
+  };
 ```
 
-This prop allows you to customize each individual bar in the stacked bar chart. You can use this to customize the `children` of each bar as well, allowing for things like `LinearGradients`, etc. See the example repo for more information.
+This prop allows you to customize each individual segment in the stacked bar chart. `seriesIndex` and `datumIndex` identify the rendered series and datum; `columnIndex` and `rowIndex` are kept as backwards-compatible aliases for the same values. `isStart` identifies the segment closest to the baseline for that positive or negative stack, and `isEnd` identifies the outer visible end of that stack. `isBottom` and `isTop` remain available for vertical stacked bars and are derived from `isStart`/`isEnd`, including negative values. You can also customize the `children` of each segment, allowing for things like `LinearGradients`, etc. See the example repo for more information.
+
+For stacked bars inside `CartesianChart orientation="horizontal"`, use [`HorizontalStackedBar`](./horizontal-stacked-bar.md).

--- a/website/docs/cartesian/bar/use-stacked-bar-paths.md
+++ b/website/docs/cartesian/bar/use-stacked-bar-paths.md
@@ -19,12 +19,23 @@ useStackedBarPaths({
     rowIndex,
     isBottom,
     isTop,
+    seriesIndex,
+    datumIndex,
+    isStart,
+    isEnd,
   }: {
     isBottom: boolean;
     isTop: boolean;
     columnIndex: number;
     rowIndex: number;
-  }) => CustomizablePathProps & { roundedCorners?: RoundedCorners };
+    isStart: boolean;
+    isEnd: boolean;
+    seriesIndex: number;
+    datumIndex: number;
+  }) => CustomizablePathProps & {
+    roundedCorners?: RoundedCorners;
+    children?: React.ReactNode;
+  };
 }): StackedBarPath[];
 ```
 
@@ -65,15 +76,26 @@ barOptions?: ({
     rowIndex,
     isBottom,
     isTop,
+    seriesIndex,
+    datumIndex,
+    isStart,
+    isEnd,
   }: {
     isBottom: boolean;
     isTop: boolean;
     columnIndex: number;
     rowIndex: number;
-  }) => CustomizablePathProps & { roundedCorners?: RoundedCorners };
+    isStart: boolean;
+    isEnd: boolean;
+    seriesIndex: number;
+    datumIndex: number;
+  }) => CustomizablePathProps & {
+    roundedCorners?: RoundedCorners;
+    children?: React.ReactNode;
+  };
 ```
 
-This prop allows you to customize each individual bar in the stacked bar chart. You can use this to customize the children of each bar as well, allowing for things like `LinearGradients`, etc. See the example repo for more information.
+This prop allows you to customize each individual segment in the stacked bar chart. `seriesIndex` and `datumIndex` identify the rendered series and datum; `columnIndex` and `rowIndex` are kept as backwards-compatible aliases for the same values. `isStart` identifies the segment closest to the baseline for that positive or negative stack, and `isEnd` identifies the outer visible end of that stack. `isBottom` and `isTop` remain available for vertical stacked bars and are derived from `isStart`/`isEnd`, including negative values. You can also customize the children of each segment, allowing for things like `LinearGradients`, etc. See the example repo for more information.
 
 ## Returns
 
@@ -90,3 +112,5 @@ type StackedBarPath = {
 ```
 
 This can then be used to draw the stacked bar chart.
+
+For horizontal stacked paths, use `useHorizontalStackedBarPaths` with `CartesianChart orientation="horizontal"`. Its arguments mirror this hook and its `barOptions` callback receives the horizontal `isLeft` and `isRight` screen-side fields instead of vertical `isBottom` and `isTop` fields.

--- a/website/docs/cartesian/guides/horizontal-bar-chart.md
+++ b/website/docs/cartesian/guides/horizontal-bar-chart.md
@@ -1,6 +1,6 @@
 # Horizontal Bar Chart
 
-This guide shows how to create a single-series horizontal bar chart with `CartesianChart` and `HorizontalBar`.
+This guide shows how to create horizontal bar charts with `CartesianChart` and the horizontal bar components.
 
 Horizontal bars use the same data shape as vertical bars: `xKey` points at the category field and `yKeys` point at numeric value fields. The difference is `orientation="horizontal"`. In horizontal mode, categories render on the vertical axis and numeric values render on the horizontal axis.
 
@@ -127,10 +127,24 @@ For dense charts or label-position demos, increase the relevant `domainPadding` 
 
 ## Current Scope
 
-The initial horizontal bar support covers single-series `HorizontalBar` charts and grouped `HorizontalBarGroup` charts. Horizontal bar marks should be rendered inside `CartesianChart orientation="horizontal"`.
-
-Stacked horizontal bars are not part of these components yet; use `StackedBar` for vertical stacked charts.
+Horizontal bar support covers single-series `HorizontalBar` charts, grouped `HorizontalBarGroup` charts, and stacked `HorizontalStackedBar` charts. Horizontal bar marks should be rendered inside `CartesianChart orientation="horizontal"`.
 
 When using `chartPressState`, the state fields keep their data roles rather than their screen-axis roles. `state.x.value.value` is still the raw category from `xKey`, while `state.x.position.value` is that category's vertical screen position. `state.y[key].value.value` is still the numeric series value, while `state.y[key].position.value` is that value's horizontal screen position.
 
-For API details, see the [`HorizontalBar` component reference](../bar/horizontal-bar.md) and [`HorizontalBarGroup` component reference](../bar/horizontal-bar-group.md).
+Horizontal mode is currently a bar-mark feature. Line, area, stacked area, and scatter marks do not automatically transpose in a horizontal chart. The current horizontal bar components are designed around a linear value axis with a zero baseline; log value axes, custom non-zero baselines, multi-axis horizontal value charts, and category viewport/windowing are later parity work.
+
+## Migrating From Victory Web
+
+Victory web supports horizontal bars by setting `horizontal` on bar-oriented components. Victory Native XL uses chart-level `orientation="horizontal"` plus explicit horizontal mark components:
+
+```tsx
+<CartesianChart orientation="horizontal" {...chartProps}>
+  {({ points, chartBounds }) => (
+    <HorizontalBar points={points.revenue} chartBounds={chartBounds} />
+  )}
+</CartesianChart>
+```
+
+Use `domain={{ x: [...] }}` for the numeric value domain in horizontal mode. For stacked horizontal bars, set the value domain to cover the cumulative positive and negative stack totals, not only the largest individual series value.
+
+For API details, see the [bar overview](../bar/overview.md), [`HorizontalBar` component reference](../bar/horizontal-bar.md), [`HorizontalBarGroup` component reference](../bar/horizontal-bar-group.md), and [`HorizontalStackedBar` component reference](../bar/horizontal-stacked-bar.md).

--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -88,7 +88,7 @@ Now we've got a line path to represent our daily high temperature data!
 
 ### Add some axes
 
-You might want some axes to make your line graph a bit easier to read and interpret. The `CartesianChart` offers [out-of-the-box support for axes and grids](./cartesian/cartesian-chart.md#axisoptions) to make it easy to get up and running with some axes. Let's add some now.
+You might want some axes to make your line graph a bit easier to read and interpret. The `CartesianChart` offers [out-of-the-box support for axes and grids](./cartesian/cartesian-chart.md#axisoptions-deprecated) to make it easy to get up and running with some axes. Let's add some now.
 
 ```tsx
 import { View } from "react-native";

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -43,10 +43,12 @@ const sidebars = {
           type: "category",
           label: "Bar Paths",
           items: [
+            "cartesian/bar/overview",
             "cartesian/bar/bar",
             "cartesian/bar/use-bar-path",
             "cartesian/bar/horizontal-bar",
             "cartesian/bar/horizontal-bar-group",
+            "cartesian/bar/horizontal-stacked-bar",
             "cartesian/bar/bar-group",
             "cartesian/bar/use-bar-group-paths",
             "cartesian/bar/stacked-bar",


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/victory-native-xl/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

Adds horizontal stacked bar chart support for `CartesianChart orientation="horizontal"`.

This introduces `HorizontalStackedBar` and `useHorizontalStackedBarPaths`, refactors shared stacked bar segment geometry so vertical and horizontal stacked bars use the same segment model, and adds touch segment lookup support for stacked bars. It also expands the example app and docs with horizontal stacked bar coverage, including mixed positive/negative stacks, touchable segments, custom segment children, and missing/zero-value segments.

Fixes # (issue)

#### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### How Has This Been Tested?

- Ran `yarn typecheck`
- Ran `yarn workspace victory-native test`
- Ran `git diff --check origin/main..HEAD`
- Ran `yarn check:code`
- Verified the horizontal stacked bar examples in the Expo example app on the iPhone Air simulator / Expo Go.


<img width="546" height="1041" alt="Screenshot 2026-06-03 at 8 35 46 AM" src="https://github.com/user-attachments/assets/0b05901b-546a-46e1-856e-dbeadcd57882" />
<img width="546" height="1041" alt="Screenshot 2026-06-03 at 8 35 38 AM" src="https://github.com/user-attachments/assets/1db10400-8308-4efa-94b0-b568b4e54886" />
<img width="546" height="1041" alt="Screenshot 2026-06-03 at 8 35 28 AM" src="https://github.com/user-attachments/assets/f8a01ff3-a6dd-413a-9011-34538fd83477" />

### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have run `yarn run check:code` and all checks pass
- [x] I have created a changeset for new features, patches, or major changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules