### PR TITLE
chore: swap pixelmatch for @blazediff/core

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ $ yarn test
 
 ### Headless golden tests
 
-Headless rendering is covered by golden PNG tests under `lib/test/headless/`. They render smoke fixtures with Skia’s Node headless API and compare output to committed reference images via `pixelmatch`. These tests run as part of `yarn test` and `yarn check:code`.
+Headless rendering is covered by golden PNG tests under `lib/test/headless/`. They render smoke fixtures with Skia’s Node headless API and compare output to committed reference images via `@blazediff/core`. These tests run as part of `yarn test` and `yarn check:code`.
 
 From the repo root:
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -49,6 +49,7 @@
     "react-native-reanimated": ">=3.0.0"
   },
   "devDependencies": {
+    "@blazediff/core": "^1.9.3",
     "@shopify/react-native-skia": "2.0.2",
     "@types/d3-scale": "^4.0.3",
     "@types/d3-shape": "^3.1.1",
@@ -57,7 +58,6 @@
     "@types/react": "~18.2.14",
     "@vitejs/plugin-react": "^4.3.4",
     "canvaskit-wasm": "^0.40.0",
-    "pixelmatch": "^7.1.0",
     "pngjs": "^7.0.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/lib/test/headless/utils/compareGoldenPng.ts
+++ b/lib/test/headless/utils/compareGoldenPng.ts
@@ -1,10 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
-import pixelmatch from "pixelmatch";
+import blazediff from "@blazediff/core";
 import { PNG } from "pngjs";
 
 const PIXEL_TOLERANCE_FRACTION = 0.001;
-const PIXELMATCH_THRESHOLD = 0.1;
+const DIFF_THRESHOLD = 0.1;
 
 export function compareGoldenPng(
   actual: Buffer,
@@ -36,13 +36,13 @@ export function compareGoldenPng(
   }
 
   const diff = new PNG({ width: expected.width, height: expected.height });
-  const diffPixels = pixelmatch(
+  const diffPixels = blazediff(
     Uint8Array.from(expected.data),
     Uint8Array.from(received.data),
     Uint8Array.from(diff.data),
     expected.width,
     expected.height,
-    { threshold: PIXELMATCH_THRESHOLD },
+    { threshold: DIFF_THRESHOLD },
   );
 
   const maxDiffPixels = Math.ceil(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1770,6 +1770,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@blazediff/core@npm:^1.9.3":
+  version: 1.9.3
+  resolution: "@blazediff/core@npm:1.9.3"
+  checksum: 10c0/5c53fc0d993f8a6f63956a7e1c72e0117f23191354e8215ca9f32aa577ae9a7cabb61c73b7fe9fb50b1d5aeb642014d73e653a038716c2586b9faa318fd48283
+  languageName: node
+  linkType: hard
+
 "@changesets/apply-release-plan@npm:^7.1.1":
   version: 7.1.1
   resolution: "@changesets/apply-release-plan@npm:7.1.1"
@@ -9659,17 +9666,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pixelmatch@npm:^7.1.0":
-  version: 7.2.0
-  resolution: "pixelmatch@npm:7.2.0"
-  dependencies:
-    pngjs: "npm:^7.0.0"
-  bin:
-    pixelmatch: bin/pixelmatch
-  checksum: 10c0/d8a2454ecf3a977738d6050ed087effa0a9f1b53a0da92d37381a74bb04db5c21e14cfcd41965fbdac4a5967aa5ff2525e2afe9826a77eae043b8339dafc53b6
-  languageName: node
-  linkType: hard
-
 "pkg-up@npm:^3.1.0":
   version: 3.1.0
   resolution: "pkg-up@npm:3.1.0"
@@ -11921,6 +11917,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "victory-native@workspace:lib"
   dependencies:
+    "@blazediff/core": "npm:^1.9.3"
     "@shopify/react-native-skia": "npm:2.0.2"
     "@types/d3-scale": "npm:^4.0.3"
     "@types/d3-shape": "npm:^3.1.1"
@@ -11933,7 +11930,6 @@ __metadata:
     d3-shape: "npm:^3.2.0"
     d3-zoom: "npm:^3.0.0"
     its-fine: "npm:^1.2.5"
-    pixelmatch: "npm:^7.1.0"
     pngjs: "npm:^7.0.0"
     react: "npm:19.0.0"
     react-dom: "npm:19.0.0"


### PR DESCRIPTION
**What:** Swap pixelmatch for `@blazediff/core` in the headless golden-PNG comparison path.
**Why:** Identical pixel-diff results, ~1.5x faster, zero dependencies.
**How:** Drop-in replacement. Same call signature and threshold option, no logic changes.
**Notes:** `@blazediff/core` is already used by Vitest, Shopify, Ant Design, Vega, and ApexCharts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)